### PR TITLE
inject、provideを利用したログインユーザーの状態管理実装#13

### DIFF
--- a/backend/app/controllers/api/v1/users_controller.rb
+++ b/backend/app/controllers/api/v1/users_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::UsersController < ApplicationController
-  before_action :authenticate_api_v1_user!, only: [:index]
+  # before_action :authenticate_api_v1_user!, only: [:index]
 
   def show
     render json: User.find(params[:id])
@@ -9,6 +9,4 @@ class Api::V1::UsersController < ApplicationController
     render json: current_api_v1_user
   end
 
-  # 
-  # ログイン後の一覧表示ではcurrent_user取得されないので、それの処理
 end

--- a/frontend/components/Footer.vue
+++ b/frontend/components/Footer.vue
@@ -1,13 +1,7 @@
 <template>
-  <v-app dark>
-    <Header />
-    <v-main>
-      <v-container>
-        <Nuxt />
-      </v-container>
-    </v-main>
-    <Footer />
-  </v-app>
+  <v-footer color="#6abe83" app dark>
+    <span>&copy; {{ new Date().getFullYear() }}</span>
+  </v-footer>
 </template>
 
 <script lang="ts">

--- a/frontend/components/Header.vue
+++ b/frontend/components/Header.vue
@@ -1,0 +1,85 @@
+<template>
+  <v-app-bar color="#6abe83" app dark>
+    <v-toolbar-title>
+      <v-btn text to="/" nuxt class="title font-weight-bold">
+        ピアノ動画シェア（仮）
+      </v-btn>
+    </v-toolbar-title>
+    <v-spacer></v-spacer>
+    <v-toolbar-items>
+      <v-btn text to="/signup" nuxt v-if="!$auth.loggedIn">
+        新規登録
+      </v-btn>
+      <v-btn text to="/login" nuxt v-if="!$auth.loggedIn">
+        ログイン
+      </v-btn>
+      <v-btn text :to="`/users/${user.id}`" nuxt v-if="$auth.loggedIn">
+        プロフィール
+      </v-btn>
+      <v-btn text v-if="$auth.loggedIn" @click="logout">
+        ログアウト
+      </v-btn>
+    </v-toolbar-items>
+  </v-app-bar>
+</template>
+
+<script lang="ts">
+import {
+  defineComponent,
+  useContext,
+  reactive,
+  useFetch,
+} from '@nuxtjs/composition-api'
+
+export default defineComponent({
+  setup() {
+    const { $auth, $axios } = useContext()
+
+    interface User {
+      id: number
+    }
+
+    const user = reactive<User>({
+      id: 0,
+    })
+
+    useFetch(async () => {
+      try {
+        const currentUser = await $axios.$get('/api/v1/users', {
+          headers: {
+            'access-token': localStorage.getItem('access-token'),
+            client: localStorage.getItem('client'),
+            uid: localStorage.getItem('uid'),
+            'token-type': localStorage.getItem('token-type'),
+          },
+        })
+        user.id = currentUser.id
+        console.log('kazuya')
+        console.log(currentUser)
+        console.log(user.id)
+      } catch (e) {
+        console.log(e)
+      }
+    })
+
+    const logout = async () => {
+      await $auth
+        .logout()
+        .then(() => {
+          localStorage.removeItem('access-token')
+          localStorage.removeItem('client')
+          localStorage.removeItem('uid')
+          localStorage.removeItem('token-type')
+        })
+        .catch((e) => {
+          console.log(e)
+        })
+    }
+
+    return {
+      user,
+      logout,
+    }
+  },
+})
+</script>

--- a/frontend/components/Header.vue
+++ b/frontend/components/Header.vue
@@ -30,11 +30,22 @@ import { UseUser } from '@/store/user/userTypes'
 
 export default defineComponent({
   setup() {
-    const { $auth } = useContext()
+    const { $auth, $axios } = useContext()
 
-    const { user } = inject(userKey) as UseUser
+    const { user, unsetUser } = inject(userKey) as UseUser
 
     const logout = async () => {
+      await $axios
+        .delete('/api/v1/auth/sign_out', {
+          headers: {
+            'access-token': localStorage.getItem('access-token'),
+            client: localStorage.getItem('client'),
+            uid: localStorage.getItem('uid'),
+            'token-type': localStorage.getItem('token-type'),
+          },
+        })
+        .catch((e) => console.log(e))
+      await unsetUser()
       await $auth
         .logout()
         .then(() => {

--- a/frontend/components/Header.vue
+++ b/frontend/components/Header.vue
@@ -13,13 +13,7 @@
       <v-btn text to="/login" nuxt v-if="!$auth.loggedIn">
         ログイン
       </v-btn>
-      <v-btn
-        text
-        :to="`/users/${user.id}`"
-        nuxt
-        v-if="$auth.loggedIn"
-        @click="test"
-      >
+      <v-btn text :to="`/users/${user.id}`" nuxt v-if="$auth.loggedIn">
         プロフィール
       </v-btn>
       <v-btn text v-if="$auth.loggedIn" @click="logout">

--- a/frontend/components/Header.vue
+++ b/frontend/components/Header.vue
@@ -13,7 +13,13 @@
       <v-btn text to="/login" nuxt v-if="!$auth.loggedIn">
         ログイン
       </v-btn>
-      <v-btn text :to="`/users/${user.id}`" nuxt v-if="$auth.loggedIn">
+      <v-btn
+        text
+        :to="`/users/${user.id}`"
+        nuxt
+        v-if="$auth.loggedIn"
+        @click="test"
+      >
         プロフィール
       </v-btn>
       <v-btn text v-if="$auth.loggedIn" @click="logout">
@@ -24,43 +30,15 @@
 </template>
 
 <script lang="ts">
-import {
-  defineComponent,
-  useContext,
-  reactive,
-  useFetch,
-} from '@nuxtjs/composition-api'
+import { defineComponent, useContext, inject } from '@nuxtjs/composition-api'
+import userKey from '@/store/user/userKey'
+import { UseUser } from '@/store/user/userTypes'
 
 export default defineComponent({
   setup() {
-    const { $auth, $axios } = useContext()
+    const { $auth } = useContext()
 
-    interface User {
-      id: number
-    }
-
-    const user = reactive<User>({
-      id: 0,
-    })
-
-    useFetch(async () => {
-      try {
-        const currentUser = await $axios.$get('/api/v1/users', {
-          headers: {
-            'access-token': localStorage.getItem('access-token'),
-            client: localStorage.getItem('client'),
-            uid: localStorage.getItem('uid'),
-            'token-type': localStorage.getItem('token-type'),
-          },
-        })
-        user.id = currentUser.id
-        console.log('kazuya')
-        console.log(currentUser)
-        console.log(user.id)
-      } catch (e) {
-        console.log(e)
-      }
-    })
+    const { user } = inject(userKey) as UseUser
 
     const logout = async () => {
       await $auth

--- a/frontend/layouts/default.vue
+++ b/frontend/layouts/default.vue
@@ -11,7 +11,13 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from '@nuxtjs/composition-api'
+import { defineComponent, provide } from '@nuxtjs/composition-api'
+import userKey from '@/store/user/userKey'
+import useUser from '@/store/user/useUser'
 
-export default defineComponent({})
+export default defineComponent({
+  setup() {
+    provide(userKey, useUser)
+  },
+})
 </script>

--- a/frontend/nuxt.config.js
+++ b/frontend/nuxt.config.js
@@ -97,6 +97,11 @@ export default {
             method: 'post',
             propertyName: 'access_token',
           },
+          // methodがdeleteにならず、postになる
+          // logout: {
+          //   url: '/api/v1/auth/sign_out',
+          //   method: 'delete',
+          // },
           logout: false,
           user: false,
           // {

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -8,6 +8,7 @@
       <v-card>
         <v-card-title class="headline">
           投稿一覧ページ（予定）
+          {{ user }}
         </v-card-title>
         <v-card-text>
           <p>
@@ -84,3 +85,46 @@
     </v-col>
   </v-row>
 </template>
+
+<script lang="ts">
+import {
+  defineComponent,
+  useContext,
+  reactive,
+  useFetch,
+  inject,
+} from '@nuxtjs/composition-api'
+import userKey from '@/store/user/userKey'
+import { UseUser } from '@/store/user/userTypes'
+
+export default defineComponent({
+  setup() {
+    const { $axios } = useContext()
+
+    const { user, setUserId } = inject(userKey) as UseUser
+
+    useFetch(async () => {
+      try {
+        const currentUser = await $axios.$get('/api/v1/users', {
+          headers: {
+            'access-token': localStorage.getItem('access-token'),
+            client: localStorage.getItem('client'),
+            uid: localStorage.getItem('uid'),
+            'token-type': localStorage.getItem('token-type'),
+          },
+        })
+        setUserId(currentUser.id)
+        console.log('kazuya')
+        console.log(currentUser)
+        console.log(user.id)
+      } catch (e) {
+        console.log(e)
+      }
+    })
+
+    return {
+      user,
+    }
+  },
+})
+</script>

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -1,125 +1,28 @@
 <template>
   <v-row justify="center" align="center">
     <v-col cols="12" sm="8" md="6">
-      <v-card class="logo py-4 d-flex justify-center">
-        <NuxtLogo />
-        <VuetifyLogo />
-      </v-card>
+      <v-card class="logo py-4 d-flex justify-center"></v-card>
       <v-card>
         <v-card-title class="headline">
           投稿一覧ページ（予定）
           {{ user }}
         </v-card-title>
-        <v-card-text>
-          <p>
-            Vuetify is a progressive Material Design component framework for
-            Vue.js. It was designed to empower developers to create amazing
-            applications.
-          </p>
-          <p>
-            For more information on Vuetify, check out the
-            <a
-              href="https://vuetifyjs.com"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              documentation
-            </a>
-            .
-          </p>
-          <p>
-            If you have questions, please join the official
-            <a
-              href="https://chat.vuetifyjs.com/"
-              target="_blank"
-              rel="noopener noreferrer"
-              title="chat"
-            >
-              discord
-            </a>
-            .
-          </p>
-          <p>
-            Find a bug? Report it on the github
-            <a
-              href="https://github.com/vuetifyjs/vuetify/issues"
-              target="_blank"
-              rel="noopener noreferrer"
-              title="contribute"
-            >
-              issue board
-            </a>
-            .
-          </p>
-          <p>
-            Thank you for developing with Vuetify and I look forward to bringing
-            more exciting features in the future.
-          </p>
-          <div class="text-xs-right">
-            <em><small>&mdash; John Leider</small></em>
-          </div>
-          <hr class="my-3" />
-          <a
-            href="https://nuxtjs.org/"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Nuxt Documentation
-          </a>
-          <br />
-          <a
-            href="https://github.com/nuxt/nuxt.js"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Nuxt GitHub
-          </a>
-        </v-card-text>
-        <v-card-actions>
-          <v-spacer />
-          <v-btn color="primary" nuxt to="/inspire">
-            Continue
-          </v-btn>
-        </v-card-actions>
       </v-card>
     </v-col>
   </v-row>
 </template>
 
 <script lang="ts">
-import {
-  defineComponent,
-  useContext,
-  reactive,
-  useFetch,
-  inject,
-} from '@nuxtjs/composition-api'
+import { defineComponent, useFetch, inject } from '@nuxtjs/composition-api'
 import userKey from '@/store/user/userKey'
 import { UseUser } from '@/store/user/userTypes'
 
 export default defineComponent({
   setup() {
-    const { $axios } = useContext()
-
-    const { user, setUserId } = inject(userKey) as UseUser
+    const { user, fetchUser } = inject(userKey) as UseUser
 
     useFetch(async () => {
-      try {
-        const currentUser = await $axios.$get('/api/v1/users', {
-          headers: {
-            'access-token': localStorage.getItem('access-token'),
-            client: localStorage.getItem('client'),
-            uid: localStorage.getItem('uid'),
-            'token-type': localStorage.getItem('token-type'),
-          },
-        })
-        setUserId(currentUser.id)
-        console.log('kazuya')
-        console.log(currentUser)
-        console.log(user.id)
-      } catch (e) {
-        console.log(e)
-      }
+      await fetchUser()
     })
 
     return {

--- a/frontend/pages/login.vue
+++ b/frontend/pages/login.vue
@@ -38,17 +38,13 @@ export default defineComponent({
     const { $auth } = useContext()
 
     interface User {
-      name: string
       email: string
       password: string
-      password_confirmation: string
     }
 
     const user = reactive<User>({
-      name: '',
       email: '',
       password: '',
-      password_confirmation: '',
     })
 
     const mockBadckendErrors: string[] = []

--- a/frontend/pages/login.vue
+++ b/frontend/pages/login.vue
@@ -31,12 +31,7 @@
 </template>
 
 <script lang="ts">
-import {
-  defineComponent,
-  reactive,
-  useContext,
-  inject,
-} from '@nuxtjs/composition-api'
+import { defineComponent, reactive, useContext } from '@nuxtjs/composition-api'
 
 export default defineComponent({
   setup() {

--- a/frontend/pages/users/_id.vue
+++ b/frontend/pages/users/_id.vue
@@ -4,6 +4,7 @@
       <v-card-title>
         <h1 class="headline">
           プロフィール
+          {{ user }}
         </h1>
         <v-spacer></v-spacer>
         <v-card-actions>
@@ -39,51 +40,54 @@ import {
   defineComponent,
   useContext,
   useRoute,
-  useRouter,
   reactive,
   useFetch,
+  inject,
 } from '@nuxtjs/composition-api'
+import userKey from '@/store/user/userKey'
+import { UseUser } from '@/store/user/userTypes'
 
 export default defineComponent({
   setup() {
     const { $http } = useContext()
     const route = useRoute()
-    const router = useRouter()
 
-    const id = Number(route.value.params.id)
+    const { user } = inject(userKey) as UseUser
 
-    interface User {
-      allow_password_change: boolean
-      created_at: string
-      email: string
-      id: number
-      name: string
-      provider: string
-      uid: string
-      updated_at: string
-    }
+    // const id = Number(route.value.params.id)
 
-    const user = reactive<User>({
-      allow_password_change: false,
-      created_at: '',
-      email: '',
-      id: 0,
-      name: '',
-      provider: '',
-      uid: '',
-      updated_at: '',
-    })
+    // interface User {
+    //   allow_password_change: boolean
+    //   created_at: string
+    //   email: string
+    //   id: number
+    //   name: string
+    //   provider: string
+    //   uid: string
+    //   updated_at: string
+    // }
 
-    useFetch(async () => {
-      try {
-        const gotUser: User = await $http.$get(`/api/v1/users/${id}`)
-        user.name = gotUser.name
-        user.email = gotUser.email
-        user.uid = gotUser.uid
-      } catch (e) {
-        console.log(e)
-      }
-    })
+    // const user = reactive<User>({
+    //   allow_password_change: false,
+    //   created_at: '',
+    //   email: '',
+    //   id: 0,
+    //   name: '',
+    //   provider: '',
+    //   uid: '',
+    //   updated_at: '',
+    // })
+
+    // useFetch(async () => {
+    //   try {
+    //     const gotUser: User = await $http.$get(`/api/v1/users/${id}`)
+    //     user.name = gotUser.name
+    //     user.email = gotUser.email
+    //     user.uid = gotUser.uid
+    //   } catch (e) {
+    //     console.log(e)
+    //   }
+    // })
 
     const deleteUser = () => {}
 

--- a/frontend/pages/users/_id.vue
+++ b/frontend/pages/users/_id.vue
@@ -4,7 +4,6 @@
       <v-card-title>
         <h1 class="headline">
           プロフィール
-          {{ user }}
         </h1>
         <v-spacer></v-spacer>
         <v-card-actions>
@@ -36,58 +35,17 @@
 </template>
 
 <script lang="ts">
-import {
-  defineComponent,
-  useContext,
-  useRoute,
-  reactive,
-  useFetch,
-  inject,
-} from '@nuxtjs/composition-api'
+import { defineComponent, useFetch, inject } from '@nuxtjs/composition-api'
 import userKey from '@/store/user/userKey'
 import { UseUser } from '@/store/user/userTypes'
 
 export default defineComponent({
   setup() {
-    const { $http } = useContext()
-    const route = useRoute()
+    const { user, fetchUser } = inject(userKey) as UseUser
 
-    const { user } = inject(userKey) as UseUser
-
-    // const id = Number(route.value.params.id)
-
-    // interface User {
-    //   allow_password_change: boolean
-    //   created_at: string
-    //   email: string
-    //   id: number
-    //   name: string
-    //   provider: string
-    //   uid: string
-    //   updated_at: string
-    // }
-
-    // const user = reactive<User>({
-    //   allow_password_change: false,
-    //   created_at: '',
-    //   email: '',
-    //   id: 0,
-    //   name: '',
-    //   provider: '',
-    //   uid: '',
-    //   updated_at: '',
-    // })
-
-    // useFetch(async () => {
-    //   try {
-    //     const gotUser: User = await $http.$get(`/api/v1/users/${id}`)
-    //     user.name = gotUser.name
-    //     user.email = gotUser.email
-    //     user.uid = gotUser.uid
-    //   } catch (e) {
-    //     console.log(e)
-    //   }
-    // })
+    useFetch(async () => {
+      await fetchUser()
+    })
 
     const deleteUser = () => {}
 

--- a/frontend/store/user/useUser.ts
+++ b/frontend/store/user/useUser.ts
@@ -1,19 +1,19 @@
 import { reactive, readonly } from '@nuxtjs/composition-api'
-import { User, UseUser } from '@/composables/user/userTypes'
+import { User, UseUser } from '@/store/user/userTypes'
 
 const user = reactive<User>({
-  allow_password_change: false,
-  created_at: '',
-  email: '',
   id: 0,
   name: '',
-  provider: '',
-  uid: '',
-  updated_at: '',
+  email: '',
 })
+
+const setUserId = (id: number) => {
+  user.id = id
+}
 
 const useUser: UseUser = {
   user: readonly(user),
+  setUserId,
 }
 
 export default useUser

--- a/frontend/store/user/useUser.ts
+++ b/frontend/store/user/useUser.ts
@@ -1,5 +1,6 @@
 import { reactive, readonly } from '@nuxtjs/composition-api'
 import { User, UseUser } from '@/store/user/userTypes'
+import axios from 'axios'
 
 const user = reactive<User>({
   id: 0,
@@ -7,13 +8,31 @@ const user = reactive<User>({
   email: '',
 })
 
-const setUserId = (id: number) => {
+const setUser = (id: number, name: string, email: string) => {
   user.id = id
+  user.name = name
+  user.email = email
+}
+
+const fetchUser = async () => {
+  try {
+    const currentUser: any = await axios.get('/api/v1/users', {
+      headers: {
+        'access-token': localStorage.getItem('access-token'),
+        client: localStorage.getItem('client'),
+        uid: localStorage.getItem('uid'),
+        'token-type': localStorage.getItem('token-type'),
+      },
+    })
+    setUser(currentUser.data.id, currentUser.data.name, currentUser.data.email)
+  } catch (e) {
+    console.log(e)
+  }
 }
 
 const useUser: UseUser = {
   user: readonly(user),
-  setUserId,
+  fetchUser,
 }
 
 export default useUser

--- a/frontend/store/user/useUser.ts
+++ b/frontend/store/user/useUser.ts
@@ -30,9 +30,16 @@ const fetchUser = async () => {
   }
 }
 
+const unsetUser = () => {
+  user.id = 0
+  user.name = ''
+  user.email = ''
+}
+
 const useUser: UseUser = {
   user: readonly(user),
   fetchUser,
+  unsetUser,
 }
 
 export default useUser

--- a/frontend/store/user/userKey.ts
+++ b/frontend/store/user/userKey.ts
@@ -1,5 +1,5 @@
 import { InjectionKey } from '@nuxtjs/composition-api'
-import { UseUser } from '@/composables/user/userTypes'
+import { UseUser } from '@/store/user/userTypes'
 
 const userKey: InjectionKey<UseUser> = Symbol('UseUser')
 export default userKey

--- a/frontend/store/user/userTypes.ts
+++ b/frontend/store/user/userTypes.ts
@@ -9,4 +9,5 @@ export interface User {
 export interface UseUser {
   user: DeepReadonly<User>
   fetchUser: () => void
+  unsetUser: () => void
 }

--- a/frontend/store/user/userTypes.ts
+++ b/frontend/store/user/userTypes.ts
@@ -8,5 +8,5 @@ export interface User {
 
 export interface UseUser {
   user: DeepReadonly<User>
-  setUserId: (id: number) => void
+  fetchUser: () => void
 }

--- a/frontend/store/user/userTypes.ts
+++ b/frontend/store/user/userTypes.ts
@@ -1,16 +1,12 @@
 import { DeepReadonly } from '@nuxtjs/composition-api'
 
 export interface User {
-  allow_password_change: boolean
-  created_at: string
-  email: string
   id: number
   name: string
-  provider: string
-  uid: string
-  updated_at: string
+  email: string
 }
 
 export interface UseUser {
   user: DeepReadonly<User>
+  setUserId: (id: number) => void
 }


### PR DESCRIPTION
・ログイン後、投稿一覧ページに遷移。その際、ログインユーザーの情報を取得することで、ヘッダーからプロフィールページに移動することが目的。

・そのため、ログインユーザーの状態を管理する、useUserを作成し、共通して利用できるように実装しました。

・流れとしては①ログイン後、一覧ページが表示される際、useUserにログインユーザー情報をセット②このおかげで、ログインユーザーのidが取得できる③そのidを元に、プロフィールページへ移動。

・また、プロフィールページについても、データをサーバーから取得するのではなく、useUserを利用しています。

・ただし、リロードを行うと状態が消えるため、その際にはログインユーザーの状態をサーバーから取得し、useUserにセットする機能も実装しています。

・尚、ログアウトについても、サーバー側のログインユーザー削除、useUserの状態の初期化などを追加実装しています。