### PR TITLE
ユーザー削除機能、編集機能の作成 #15

### DIFF
--- a/backend/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/backend/app/controllers/api/v1/auth/registrations_controller.rb
@@ -1,5 +1,14 @@
 class Api::V1::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsController
 
+  def create
+    user = User.new(sign_up_params)
+    if user.save
+      render json: user
+    else
+      render json: { errors: user.errors.full_messages }, status: 422
+    end
+  end
+
   # def destroy
   #   user = User.find_by(params[:id])
   #   user.destroy!

--- a/backend/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/backend/app/controllers/api/v1/auth/registrations_controller.rb
@@ -9,15 +9,13 @@ class Api::V1::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsCon
     end
   end
 
-  # def destroy
-  #   user = User.find_by(params[:id])
-  #   user.destroy!
-  #   render json: user
-  # end
-
   private
 
   def sign_up_params
     params.require(:registration).permit(:name, :email, :password, :password_confirmation)
+  end
+
+  def account_update_params
+    params.require(:registration).permit(:name, :email)
   end
 end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -5,7 +5,6 @@ Rails.application.routes.draw do
         registrations: "api/v1/auth/registrations"
       }
 			resources :users, only: [:index, :show]
-      get '/users/kazuya', to: 'users#kazuya'
     end
   end
 end

--- a/frontend/components/Header.vue
+++ b/frontend/components/Header.vue
@@ -13,7 +13,7 @@
       <v-btn text to="/login" nuxt v-if="!$auth.loggedIn">
         ログイン
       </v-btn>
-      <v-btn text :to="`/users/${user.id}`" nuxt v-if="$auth.loggedIn">
+      <v-btn text :to="`/users/${user.id}/show`" nuxt v-if="$auth.loggedIn">
         プロフィール
       </v-btn>
       <v-btn text v-if="$auth.loggedIn" @click="logout">

--- a/frontend/components/user/DeleteModal.vue
+++ b/frontend/components/user/DeleteModal.vue
@@ -1,0 +1,69 @@
+<template>
+  <v-dialog v-model="dialog.isDisplay" width="500">
+    <v-card>
+      <v-card-title class="text-h5 grey lighten-2">
+        本当に削除しますか？
+      </v-card-title>
+      <v-divider></v-divider>
+      <v-card-actions>
+        <v-spacer></v-spacer>
+        <v-btn color="#f06966" text @click="deleteUser">
+          削除する
+        </v-btn>
+        <v-btn color="#6abe83" text @click="dialog.isDisplay = false">
+          戻る
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script lang="ts">
+import { defineComponent, useContext, inject } from '@nuxtjs/composition-api'
+import userKey from '@/store/user/userKey'
+import { UseUser } from '@/store/user/userTypes'
+
+export default defineComponent({
+  props: {
+    dialog: {
+      type: Object,
+      required: true,
+    },
+  },
+
+  setup() {
+    const { $axios, $auth } = useContext()
+
+    const { unsetUser } = inject(userKey) as UseUser
+
+    const deleteUser = async () => {
+      await $axios
+        .$delete('/api/v1/auth', {
+          headers: {
+            'access-token': localStorage.getItem('access-token'),
+            client: localStorage.getItem('client'),
+            uid: localStorage.getItem('uid'),
+            'token-type': localStorage.getItem('token-type'),
+          },
+        })
+        .catch((e) => console.log(e))
+      await unsetUser()
+      await $auth
+        .logout()
+        .then(() => {
+          localStorage.removeItem('access-token')
+          localStorage.removeItem('client')
+          localStorage.removeItem('uid')
+          localStorage.removeItem('token-type')
+        })
+        .catch((e) => {
+          console.log(e)
+        })
+    }
+
+    return {
+      deleteUser,
+    }
+  },
+})
+</script>

--- a/frontend/components/user/FormEmail.vue
+++ b/frontend/components/user/FormEmail.vue
@@ -2,6 +2,7 @@
   <v-text-field
     type="email"
     :rules="rules"
+    :value="user.email"
     @input="handleInput"
     prepend-icon="mdi-email"
     label="メールアドレス"
@@ -9,15 +10,20 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from '@nuxtjs/composition-api'
+import { defineComponent, inject } from '@nuxtjs/composition-api'
+import userKey from '@/store/user/userKey'
+import { UseUser } from '@/store/user/userTypes'
 
 export default defineComponent({
   setup(_, context) {
+    const { user } = inject(userKey) as UseUser
+
     const handleInput = (event: Event) => {
       context.emit('input', event)
     }
 
     return {
+      user,
       handleInput,
       rules: [
         (v: string) => !!v || '',

--- a/frontend/components/user/FormName.vue
+++ b/frontend/components/user/FormName.vue
@@ -3,6 +3,7 @@
     type="text"
     :rules="rules"
     :counter="max"
+    :value="user.name"
     @input="handleInput"
     prepend-icon="mdi-account"
     label="名前"
@@ -10,10 +11,14 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from '@nuxtjs/composition-api'
+import { defineComponent, inject } from '@nuxtjs/composition-api'
+import userKey from '@/store/user/userKey'
+import { UseUser } from '@/store/user/userTypes'
 
 export default defineComponent({
   setup(_, context) {
+    const { user } = inject(userKey) as UseUser
+
     const handleInput = (event: Event) => {
       context.emit('input', event)
     }
@@ -21,6 +26,7 @@ export default defineComponent({
     const max = 30
 
     return {
+      user,
       handleInput,
       max,
       rules: [

--- a/frontend/layouts/default.vue
+++ b/frontend/layouts/default.vue
@@ -16,6 +16,7 @@ import userKey from '@/store/user/userKey'
 import useUser from '@/store/user/useUser'
 
 export default defineComponent({
+  name: 'default',
   setup() {
     provide(userKey, useUser)
   },

--- a/frontend/nuxt.config.js
+++ b/frontend/nuxt.config.js
@@ -50,8 +50,12 @@ export default {
     '@nuxt/http',
   ],
 
+  // http: {
+  //   proxy: true,
+  // },
+
   http: {
-    proxy: true,
+    baseURL: 'http://localhost:3000',
   },
 
   proxy: {

--- a/frontend/pages/signup.vue
+++ b/frontend/pages/signup.vue
@@ -70,22 +70,29 @@ export default defineComponent({
     })
 
     const registerUser = async () => {
-      await $http.post('/api/v1/auth', user)
-      await $auth
-        .loginWith('local', {
-          data: {
-            email: user.email,
-            password: user.password,
-          },
-        })
-        .then((response: any) => {
-          localStorage.setItem('access-token', response.headers['access-token'])
-          localStorage.setItem('client', response.headers.client)
-          localStorage.setItem('uid', response.headers.uid)
-          localStorage.setItem('token-type', response.headers['token-type'])
+      await $http
+        .post('/api/v1/auth', user)
+        .then(async () => {
+          await $auth
+            .loginWith('local', {
+              data: {
+                email: user.email,
+                password: user.password,
+              },
+            })
+            .then((response: any) => {
+              localStorage.setItem(
+                'access-token',
+                response.headers['access-token'],
+              )
+              localStorage.setItem('client', response.headers.client)
+              localStorage.setItem('uid', response.headers.uid)
+              localStorage.setItem('token-type', response.headers['token-type'])
+            })
+            .catch((e) => console.log(e))
         })
         .catch((e) => {
-          const errors = e.response.data.errors.full_messages
+          const errors = e.response.data.errors
           errorMessages.backendErrors = errors
         })
     }

--- a/frontend/pages/users/_id.vue
+++ b/frontend/pages/users/_id.vue
@@ -1,5 +1,22 @@
 <template>
   <v-container>
+    <v-dialog v-model="dialog.isDisplay" width="500">
+      <v-card>
+        <v-card-title class="text-h5 grey lighten-2">
+          本当に削除しますか？
+        </v-card-title>
+        <v-divider></v-divider>
+        <v-card-actions>
+          <v-spacer></v-spacer>
+          <v-btn color="#f06966" text @click="deleteUser">
+            削除する
+          </v-btn>
+          <v-btn color="#6abe83" text @click="dialog.isDisplay = false">
+            戻る
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
     <v-card width="800px" class="mx-auto mt-5" elevation="1">
       <v-card-title>
         <h1 class="headline">
@@ -10,7 +27,11 @@
           <v-btn color="#6abe83" class="white--text mr-3">
             編集
           </v-btn>
-          <v-btn color="#f06966" class="white--text" @click="deleteUser">
+          <v-btn
+            color="#f06966"
+            class="white--text"
+            @click="dialog.isDisplay = true"
+          >
             削除
           </v-btn>
         </v-card-actions>
@@ -38,19 +59,22 @@
 import {
   defineComponent,
   useContext,
-  useRouter,
   inject,
   useFetch,
+  reactive,
 } from '@nuxtjs/composition-api'
 import userKey from '@/store/user/userKey'
 import { UseUser } from '@/store/user/userTypes'
 
 export default defineComponent({
   setup() {
-    const { $axios } = useContext()
-    const router = useRouter()
+    const { $axios, $auth } = useContext()
 
     const { user, fetchUser, unsetUser } = inject(userKey) as UseUser
+
+    const dialog = reactive({
+      isDisplay: false,
+    })
 
     useFetch(async () => {
       await fetchUser()
@@ -68,11 +92,22 @@ export default defineComponent({
         })
         .catch((e) => console.log(e))
       await unsetUser()
-      router.push('/')
+      await $auth
+        .logout()
+        .then(() => {
+          localStorage.removeItem('access-token')
+          localStorage.removeItem('client')
+          localStorage.removeItem('uid')
+          localStorage.removeItem('token-type')
+        })
+        .catch((e) => {
+          console.log(e)
+        })
     }
 
     return {
       user,
+      dialog,
       deleteUser,
     }
   },

--- a/frontend/pages/users/_id.vue
+++ b/frontend/pages/users/_id.vue
@@ -1,22 +1,6 @@
 <template>
   <v-container>
-    <v-dialog v-model="dialog.isDisplay" width="500">
-      <v-card>
-        <v-card-title class="text-h5 grey lighten-2">
-          本当に削除しますか？
-        </v-card-title>
-        <v-divider></v-divider>
-        <v-card-actions>
-          <v-spacer></v-spacer>
-          <v-btn color="#f06966" text @click="deleteUser">
-            削除する
-          </v-btn>
-          <v-btn color="#6abe83" text @click="dialog.isDisplay = false">
-            戻る
-          </v-btn>
-        </v-card-actions>
-      </v-card>
-    </v-dialog>
+    <UserDeleteModal :dialog="dialog" />
     <v-card width="800px" class="mx-auto mt-5" elevation="1">
       <v-card-title>
         <h1 class="headline">
@@ -58,7 +42,6 @@
 <script lang="ts">
 import {
   defineComponent,
-  useContext,
   inject,
   useFetch,
   reactive,
@@ -68,9 +51,7 @@ import { UseUser } from '@/store/user/userTypes'
 
 export default defineComponent({
   setup() {
-    const { $axios, $auth } = useContext()
-
-    const { user, fetchUser, unsetUser } = inject(userKey) as UseUser
+    const { user, fetchUser } = inject(userKey) as UseUser
 
     const dialog = reactive({
       isDisplay: false,
@@ -80,35 +61,9 @@ export default defineComponent({
       await fetchUser()
     })
 
-    const deleteUser = async () => {
-      await $axios
-        .$delete('/api/v1/auth', {
-          headers: {
-            'access-token': localStorage.getItem('access-token'),
-            client: localStorage.getItem('client'),
-            uid: localStorage.getItem('uid'),
-            'token-type': localStorage.getItem('token-type'),
-          },
-        })
-        .catch((e) => console.log(e))
-      await unsetUser()
-      await $auth
-        .logout()
-        .then(() => {
-          localStorage.removeItem('access-token')
-          localStorage.removeItem('client')
-          localStorage.removeItem('uid')
-          localStorage.removeItem('token-type')
-        })
-        .catch((e) => {
-          console.log(e)
-        })
-    }
-
     return {
       user,
       dialog,
-      deleteUser,
     }
   },
 })

--- a/frontend/pages/users/_id.vue
+++ b/frontend/pages/users/_id.vue
@@ -35,19 +35,41 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, useFetch, inject } from '@nuxtjs/composition-api'
+import {
+  defineComponent,
+  useContext,
+  useRouter,
+  inject,
+  useFetch,
+} from '@nuxtjs/composition-api'
 import userKey from '@/store/user/userKey'
 import { UseUser } from '@/store/user/userTypes'
 
 export default defineComponent({
   setup() {
-    const { user, fetchUser } = inject(userKey) as UseUser
+    const { $axios } = useContext()
+    const router = useRouter()
+
+    const { user, fetchUser, unsetUser } = inject(userKey) as UseUser
 
     useFetch(async () => {
       await fetchUser()
     })
 
-    const deleteUser = () => {}
+    const deleteUser = async () => {
+      await $axios
+        .$delete('/api/v1/auth', {
+          headers: {
+            'access-token': localStorage.getItem('access-token'),
+            client: localStorage.getItem('client'),
+            uid: localStorage.getItem('uid'),
+            'token-type': localStorage.getItem('token-type'),
+          },
+        })
+        .catch((e) => console.log(e))
+      await unsetUser()
+      router.push('/')
+    }
 
     return {
       user,

--- a/frontend/pages/users/_id/edit.vue
+++ b/frontend/pages/users/_id/edit.vue
@@ -1,0 +1,97 @@
+<template>
+  <v-container>
+    <v-card width="500px" class="mx-auto mt-5" elevation="1">
+      <v-card-title>
+        <h1 class="headline">
+          プロフィール編集
+        </h1>
+      </v-card-title>
+      <v-alert dense text type="error" v-if="errorMessage.backendError.length">
+        {{ errorMessage.backendError }}
+      </v-alert>
+      <v-card-text>
+        <v-form ref="form" lazy-validation>
+          <UserFormName v-model="currentUser.name" />
+          <UserFormEmail v-model="currentUser.email" />
+          {{ user }}
+          <v-card-actions>
+            <v-btn color="#6abe83" class="white--text" @click="editUser">
+              編集
+            </v-btn>
+          </v-card-actions>
+        </v-form>
+      </v-card-text>
+    </v-card>
+  </v-container>
+</template>
+
+<script lang="ts">
+import {
+  defineComponent,
+  useContext,
+  useRouter,
+  inject,
+  useFetch,
+  reactive,
+} from '@nuxtjs/composition-api'
+import userKey from '@/store/user/userKey'
+import { UseUser } from '@/store/user/userTypes'
+
+export default defineComponent({
+  setup() {
+    const { $axios } = useContext()
+    const router = useRouter()
+
+    const { user, fetchUser } = inject(userKey) as UseUser
+
+    useFetch(async () => {
+      await fetchUser()
+    })
+
+    interface CurrentUser {
+      name: string
+      email: string
+    }
+
+    const currentUser = reactive<CurrentUser>({
+      name: user.name,
+      email: user.email,
+    })
+
+    interface ErrorMessage {
+      backendError: string
+    }
+
+    const errorMessage = reactive<ErrorMessage>({
+      backendError: '',
+    })
+
+    const editUser = async () => {
+      await $axios
+        .$put('/api/v1/auth', currentUser, {
+          headers: {
+            'access-token': localStorage.getItem('access-token'),
+            client: localStorage.getItem('client'),
+            uid: localStorage.getItem('uid'),
+            'token-type': localStorage.getItem('token-type'),
+          },
+        })
+        .then(() => {
+          router.push(`/users/${user.id}/show`)
+        })
+        .catch((e) => {
+          // devise_token_authのユーザーアップデートのエラーメッセージがどうしても上手くいかないため、下記の通り記述。
+          errorMessage.backendError =
+            '入力に誤りがあるか、もしくはすでに使われているメールアドレスです。'
+        })
+    }
+
+    return {
+      currentUser,
+      user,
+      errorMessage,
+      editUser,
+    }
+  },
+})
+</script>

--- a/frontend/pages/users/_id/edit.vue
+++ b/frontend/pages/users/_id/edit.vue
@@ -18,6 +18,14 @@
             <v-btn color="#6abe83" class="white--text" @click="editUser">
               編集
             </v-btn>
+            <v-btn
+              color="#f1ac9d"
+              class="white--text"
+              :to="`/users/${user.id}/show`"
+              nuxt
+            >
+              戻る
+            </v-btn>
           </v-card-actions>
         </v-form>
       </v-card-text>

--- a/frontend/pages/users/_id/show.vue
+++ b/frontend/pages/users/_id/show.vue
@@ -8,7 +8,12 @@
         </h1>
         <v-spacer></v-spacer>
         <v-card-actions>
-          <v-btn color="#6abe83" class="white--text mr-3">
+          <v-btn
+            color="#6abe83"
+            class="white--text mr-3"
+            :to="`/users/${user.id}/edit`"
+            nuxt
+          >
             編集
           </v-btn>
           <v-btn


### PR DESCRIPTION
・ユーザー削除機能の実装。削除前にモーダルウィンドウを表示し、本当に削除するかの確認を出すように実装しました。尚、モーダルウィンドはコンポーネント化しております。

・ユーザー削除後は同時にログアウトし、投稿一覧ページ（ルート）に戻るようにしています。

・プロフィール編集ページの実装。バックエンドからのバリデーションメッセージがどうしても単一（ユーザーが見つかりませんと言うメッセージのみ）しか、取得できませんでした。そのため、バリデーションについてのメッセージはフロント側で用意しています。

・編集完了後はプロフィールページに戻るように実装しています。