### PR TITLE
直接url入力によるページ表示の禁止機能を作成 #19

### DIFF
--- a/frontend/nuxt.config.js
+++ b/frontend/nuxt.config.js
@@ -67,6 +67,10 @@ export default {
     baseURL: 'http://localhost:3000',
   },
 
+  router: {
+    middleware: ['auth'],
+  },
+
   // Vuetify module configuration: https://go.nuxtjs.dev/config-vuetify
   vuetify: {
     customVariables: ['~/assets/variables.scss'],

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -18,6 +18,7 @@ import userKey from '@/store/user/userKey'
 import { UseUser } from '@/store/user/userTypes'
 
 export default defineComponent({
+  auth: false,
   setup() {
     const { user, fetchUser } = inject(userKey) as UseUser
 

--- a/frontend/pages/login.vue
+++ b/frontend/pages/login.vue
@@ -41,6 +41,7 @@ import flashKey from '@/store/flash/flashKey'
 import { UseFlashMessage } from '@/store/flash/flashTypes'
 
 export default defineComponent({
+  auth: 'guest',
   setup() {
     const { $auth } = useContext()
 

--- a/frontend/pages/signup.vue
+++ b/frontend/pages/signup.vue
@@ -43,7 +43,7 @@ import flashKey from '@/store/flash/flashKey'
 import { UseFlashMessage } from '@/store/flash/flashTypes'
 
 export default defineComponent({
-  auth: false,
+  auth: 'guest',
   setup() {
     const { $http, $auth } = useContext()
 

--- a/frontend/pages/signup.vue
+++ b/frontend/pages/signup.vue
@@ -43,6 +43,7 @@ import flashKey from '@/store/flash/flashKey'
 import { UseFlashMessage } from '@/store/flash/flashTypes'
 
 export default defineComponent({
+  auth: false,
   setup() {
     const { $http, $auth } = useContext()
 


### PR DESCRIPTION
・基本的にはnuxt.config.jsに一括で、ログインしないとページ表示を出来ないように設定しています。

・その上で、未ログイン時でも表示を許可する場合にはauth: falseを設定することで、ページ表示ができるようにしています（今回の場合は投稿一覧ページ）。

・また、逆に非ログインユーザーのみページ表示を許可する場合はauth: 'guest'を設定して対応しています（今回の場合は新規登録、ログインページ）。

・なお、ログインが必要な場合にはログインページに、ログインしているのにログインページを表示しようとした時などは投稿一覧ページに遷移するよう設定しております。その際、簡易的なアラートメッセージが出るようにも設定しています。