### PR TITLE
動画投稿ページと投稿一覧ページのレイアウトを作成#21

### DIFF
--- a/frontend/components/Header.vue
+++ b/frontend/components/Header.vue
@@ -13,6 +13,9 @@
       <v-btn text to="/login" nuxt v-if="!$auth.loggedIn">
         ログイン
       </v-btn>
+      <v-btn text to="/posts/new" nuxt v-if="$auth.loggedIn">
+        新規投稿
+      </v-btn>
       <v-btn text :to="`/users/${user.id}/show`" nuxt v-if="$auth.loggedIn">
         プロフィール
       </v-btn>

--- a/frontend/components/post/FormComment.vue
+++ b/frontend/components/post/FormComment.vue
@@ -1,0 +1,33 @@
+<template>
+  <v-textarea
+    filled
+    :rules="rules"
+    :counter="max"
+    @input="handleInput"
+    label="投稿コメント"
+  ></v-textarea>
+</template>
+
+<script lang="ts">
+import { defineComponent } from '@nuxtjs/composition-api'
+
+export default defineComponent({
+  setup(_, context) {
+    const handleInput = (event: Event) => {
+      context.emit('input', event)
+    }
+
+    const max = 200
+
+    return {
+      handleInput,
+      max,
+      rules: [
+        (v: string) => !!v || '',
+        (v: string) =>
+          (!!v && max >= v.length) || `${max}文字以内で入力してください`,
+      ],
+    }
+  },
+})
+</script>

--- a/frontend/components/post/FormTitle.vue
+++ b/frontend/components/post/FormTitle.vue
@@ -1,0 +1,36 @@
+<template>
+  <v-text-field
+    type="text"
+    :rules="rules"
+    :counter="max"
+    @input="handleInput"
+    prepend-icon="mdi-clipboard-play-outline"
+    label="タイトル"
+  />
+</template>
+
+<script lang="ts">
+import { defineComponent } from '@nuxtjs/composition-api'
+
+export default defineComponent({
+  setup(_, context) {
+    const handleInput = (event: Event) => {
+      context.emit('input', event)
+    }
+
+    const max = 40
+
+    return {
+      handleInput,
+      max,
+      rules: [
+        // ||の左側はバリデーションの成功。!!vはvalueが存在していること。
+        // ||の右側はバリデーションのメッセージ。
+        (v: string) => !!v || '',
+        (v: string) =>
+          (!!v && max >= v.length) || `${max}文字以内で入力してください`,
+      ],
+    }
+  },
+})
+</script>

--- a/frontend/components/post/FormVideo.vue
+++ b/frontend/components/post/FormVideo.vue
@@ -1,0 +1,30 @@
+<template>
+  <v-file-input
+    :rules="rules"
+    @input="handleInput"
+    show-size
+    prepend-icon="mdi-paperclip"
+    label="動画ファイル"
+  />
+</template>
+
+<script lang="ts">
+import { defineComponent } from '@nuxtjs/composition-api'
+
+export default defineComponent({
+  setup(_, context) {
+    const handleInput = (event: Event) => {
+      context.emit('input', event)
+    }
+
+    const max = 40
+
+    return {
+      handleInput,
+      max,
+      // 動画ファイルのバリデーション方法がわからない。ファイル形式を動画限定、容量を500MB以下とか
+      rules: [(v: string) => !!v || ''],
+    }
+  },
+})
+</script>

--- a/frontend/components/post/Indivisual.vue
+++ b/frontend/components/post/Indivisual.vue
@@ -1,0 +1,36 @@
+<template>
+  <v-col cols="12" sm="8" md="4">
+    <v-card class="mx-auto" max-width="500px">
+      <!-- <v-img
+        src="https://cdn.vuetifyjs.com/images/cards/sunshine.jpg"
+        height="200px"
+      ></v-img> -->
+      <video src="~/assets/videos/test.mp4" class="preview" controls></video>
+      <v-card-title class="mb-3">
+        ここに動画のタイトル
+      </v-card-title>
+      <v-card-subtitle>
+        投稿者：Guest
+        <br />
+        投稿日時：2021/08/15
+      </v-card-subtitle>
+      <v-card-actions>
+        <v-btn color="#6abe83" text>
+          再生する
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-col>
+</template>
+
+<script lang="ts">
+import { defineComponent } from '@nuxtjs/composition-api'
+
+export default defineComponent({})
+</script>
+
+<style scoped>
+.preview {
+  width: 100%;
+}
+</style>

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -1,14 +1,11 @@
 <template>
-  <v-row justify="center" align="center">
-    <v-col cols="12" sm="8" md="6">
-      <v-card class="logo py-4 d-flex justify-center"></v-card>
-      <v-card>
-        <v-card-title class="headline">
-          投稿一覧ページ（予定）
-          {{ user }}
-        </v-card-title>
-      </v-card>
-    </v-col>
+  <v-row align="center">
+    <PostIndivisual />
+    <PostIndivisual />
+    <PostIndivisual />
+    <PostIndivisual />
+    ログインユーザー
+    {{ user }}
   </v-row>
 </template>
 

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -13,8 +13,10 @@
 import { defineComponent, useFetch, inject } from '@nuxtjs/composition-api'
 import userKey from '@/store/user/userKey'
 import { UseUser } from '@/store/user/userTypes'
+import FormComment from '~/components/post/FormComment.vue'
 
 export default defineComponent({
+  components: { FormComment },
   auth: false,
   setup() {
     const { user, fetchUser } = inject(userKey) as UseUser

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -1,12 +1,14 @@
 <template>
-  <v-row align="center">
-    <PostIndivisual />
-    <PostIndivisual />
-    <PostIndivisual />
-    <PostIndivisual />
-    ログインユーザー
-    {{ user }}
-  </v-row>
+  <div>
+    <v-row align="center">
+      <PostIndivisual />
+      <PostIndivisual />
+      <PostIndivisual />
+      <PostIndivisual />
+      ログインユーザー
+      {{ user }}
+    </v-row>
+  </div>
 </template>
 
 <script lang="ts">

--- a/frontend/pages/posts/new.vue
+++ b/frontend/pages/posts/new.vue
@@ -1,0 +1,114 @@
+<template>
+  <v-container>
+    <v-card width="500px" class="mx-auto mt-5" elevation="1">
+      <v-card-title>
+        <h1 class="headline">
+          動画投稿
+        </h1>
+      </v-card-title>
+      <v-alert
+        dense
+        text
+        type="error"
+        v-for="(error, index) in errorMessages.backendErrors"
+        :key="index"
+      >
+        {{ error }}
+      </v-alert>
+      <v-card-text>
+        <v-form ref="form" lazy-validation>
+          <PostFormTitle />
+          <PostFormVideo />
+          <PostFormComment />
+          <!-- <UserFormName v-model="user.name" />
+          <UserFormEmail v-model="user.email" />
+          <UserFormPassword v-model="user.password" />
+          <UserFormPasswordConfirmation v-model="user.password_confirmation" /> -->
+          <v-card-actions>
+            <v-btn color="#6abe83" class="white--text" @click="registerUser">
+              新規投稿
+            </v-btn>
+          </v-card-actions>
+        </v-form>
+      </v-card-text>
+    </v-card>
+  </v-container>
+</template>
+
+<script lang="ts">
+import {
+  defineComponent,
+  useContext,
+  inject,
+  reactive,
+} from '@nuxtjs/composition-api'
+import flashKey from '@/store/flash/flashKey'
+import { UseFlashMessage } from '@/store/flash/flashTypes'
+
+export default defineComponent({
+  setup() {
+    const { $http, $auth } = useContext()
+
+    const { displayFlashMessage } = inject(flashKey) as UseFlashMessage
+
+    interface User {
+      name: string
+      email: string
+      password: string
+      password_confirmation: string
+    }
+
+    const user = reactive<User>({
+      name: '',
+      email: '',
+      password: '',
+      password_confirmation: '',
+    })
+
+    const mockBadckendErrors: string[] = []
+
+    interface ErrorMessages {
+      backendErrors: string[]
+    }
+
+    const errorMessages = reactive<ErrorMessages>({
+      backendErrors: mockBadckendErrors,
+    })
+
+    const registerUser = async () => {
+      await $http
+        .post('/api/v1/auth', user)
+        .then(async () => {
+          await $auth
+            .loginWith('local', {
+              data: {
+                email: user.email,
+                password: user.password,
+              },
+            })
+            .then((response: any) => {
+              localStorage.setItem(
+                'access-token',
+                response.headers['access-token'],
+              )
+              localStorage.setItem('client', response.headers.client)
+              localStorage.setItem('uid', response.headers.uid)
+              localStorage.setItem('token-type', response.headers['token-type'])
+              displayFlashMessage('新規登録')
+            })
+            .catch((e) => console.log(e))
+        })
+        .catch((e) => {
+          const errors = e.response.data.errors
+          errorMessages.backendErrors = errors
+        })
+    }
+
+    return {
+      user,
+      errorMessages,
+      registerUser,
+    }
+  },
+})
+</script>


### PR DESCRIPTION
・index.vueに動画一覧のレイアウトを作成。個別動画のレイアウトはIndivisual.vueとしてコンポーネント化しました。

・pagesディレクトリ配下にpostsディレクトリを作成。その配下にnew.vueファイルを作成し、投稿画面のレイアウトを作成しました。なお、動画ファイル投稿のvuetifyを使ったバリデーション方法がわからなかったため、その部分については後ほど実装することとします。

・ヘッダーに投稿ボタンを作成し、投稿ページへ遷移するようにしています。