### PR TITLE
動画詳細ページの実装#29

### DIFF
--- a/backend/app/controllers/api/v1/movies_controller.rb
+++ b/backend/app/controllers/api/v1/movies_controller.rb
@@ -1,5 +1,6 @@
 class Api::V1::MoviesController < ApplicationController
-  skip_before_action :login_required, only: :index
+  skip_before_action :login_required, only: [:index, :show]
+  before_action :set_movie, only: :show
 
   def index
     render json: Movie.all, methods: [:movie_url]
@@ -14,9 +15,17 @@ class Api::V1::MoviesController < ApplicationController
     end
   end
 
+  def show
+    render json: @movie, methods: [:movie_url]
+  end
+
   private
 
   def movie_params
     params.require(:movie).permit(:title, :introduction, :movie)
+  end
+
+  def set_movie
+    @movie = Movie.find(params[:id])
   end
 end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
       get "/user", to: "auth#get_current_user"
       delete "logout", to: "auth#logout"
 			resources :users, only: [:create, :update, :destroy]
-      resources :movies, only: [:index, :create]
+      resources :movies, only: [:index, :create, :show]
     end
   end
 end

--- a/frontend/components/movie/Indivisual.vue
+++ b/frontend/components/movie/Indivisual.vue
@@ -1,6 +1,6 @@
 <template>
   <v-col cols="12" sm="8" md="4" class="test">
-    <nuxt-link to="/signup">
+    <nuxt-link :to="`/movies/${movie.id}/show`">
       <v-card class="mx-auto movie-card" max-width="500px">
         <video :src="movie.movie_url" class="preview"></video>
         <!-- <video :src="movie.movie_url" class="preview" controls></video> -->

--- a/frontend/components/movie/Indivisual.vue
+++ b/frontend/components/movie/Indivisual.vue
@@ -1,19 +1,21 @@
 <template>
-  <v-col cols="12" sm="8" md="4">
-    <v-card class="mx-auto" max-width="500px">
-      <video :src="movie.movie_url" class="preview" controls></video>
-      <v-card-title class="mb-3">
-        {{ movie.title }}
-      </v-card-title>
-      <v-card-subtitle>
-        投稿者：Guest
-        <br />
-        投稿日時：{{ new Date(movie.created_at).toLocaleString() }}
-      </v-card-subtitle>
-      <v-card-actions>
-        <v-btn color="#6abe83" text>再生する</v-btn>
-      </v-card-actions>
-    </v-card>
+  <v-col cols="12" sm="8" md="4" class="test">
+    <nuxt-link to="/signup">
+      <v-card class="mx-auto movie-card" max-width="500px">
+        <video :src="movie.movie_url" class="preview"></video>
+        <!-- <video :src="movie.movie_url" class="preview" controls></video> -->
+        <v-card-title class="text-body-1 font-weight-medium">
+          <p class="movie-title">
+            {{ movie.title }}
+          </p>
+        </v-card-title>
+        <v-card-subtitle>
+          投稿者：Guest
+          <br />
+          投稿日時：{{ new Date(movie.created_at).toLocaleString() }}
+        </v-card-subtitle>
+      </v-card>
+    </nuxt-link>
   </v-col>
 </template>
 
@@ -41,7 +43,27 @@ export default defineComponent({
 </script>
 
 <style scoped>
+a {
+  text-decoration: none;
+}
+
+.movie-card {
+  transition: all 0.1s;
+}
+
+.movie-card:hover {
+  transform: scale(1.03, 1.03);
+}
+
 .preview {
   width: 100%;
+  object-fit: cover;
+  height: 300px;
+}
+
+.movie-title {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 </style>

--- a/frontend/pages/movies/_id/show.vue
+++ b/frontend/pages/movies/_id/show.vue
@@ -1,0 +1,102 @@
+<template>
+  <v-container>
+    <!-- <UserDeleteModal :dialog="dialog" @to-dialog-false="toDialogFalse" /> -->
+    <v-card width="800px" class="mx-auto mt-5" elevation="1">
+      <video
+        :src="movie.movie_url"
+        class="preview"
+        controls
+        width="100%"
+      ></video>
+      <v-card-title>
+        <h1 class="headline">
+          {{ movie.title }}
+        </h1>
+        <v-spacer></v-spacer>
+        <v-card-actions>
+          <v-btn color="#6abe83" class="white--text mr-3" :to="`/`" nuxt>
+            編集
+          </v-btn>
+          <!-- <v-btn color="#f06966" class="white--text" @click="toDialogTrue">
+            削除
+          </v-btn> -->
+          <v-btn color="#f06966" class="white--text">
+            削除
+          </v-btn>
+        </v-card-actions>
+      </v-card-title>
+      <v-simple-table class="px-5 pb-15">
+        <template v-slot:default>
+          <tbody>
+            <tr>
+              <th class="body-1 font-weight-bold">投稿者</th>
+              <td class="body-1">（仮）</td>
+            </tr>
+            <tr>
+              <th class="body-1 font-weight-bold">投稿日</th>
+              <td class="body-1">
+                {{ new Date(movie.created_at).toLocaleString() }}
+              </td>
+            </tr>
+          </tbody>
+        </template>
+      </v-simple-table>
+    </v-card>
+    <button @click="debag">debug</button>
+    {{ movies }}
+  </v-container>
+</template>
+
+<script lang="ts">
+import {
+  defineComponent,
+  inject,
+  useRoute,
+  computed,
+  useFetch,
+  ref,
+} from '@nuxtjs/composition-api'
+import movieKey from '@/store/movie/movieKey'
+import { Movie, UseMovie } from '@/store/movie/movieTypes'
+
+export default defineComponent({
+  auth: false,
+  setup() {
+    const route = useRoute()
+    const id = computed(() => route.value.params.id)
+
+    const { movies } = inject(movieKey) as UseMovie
+
+    const movie = ref<Movie>(
+      movies.value.find((movie: Movie) => {
+        return movie.id === Number(id.value)
+      }),
+    )
+
+    const debag = () => {
+      console.log(movie)
+    }
+
+    // const dialog = ref<boolean>(false)
+
+    // const toDialogTrue = () => {
+    //   dialog.value = true
+    // }
+
+    // const toDialogFalse = () => {
+    //   dialog.value = false
+    // }
+
+    // useFetch(async () => {
+    //   await fetchUser()
+    // })
+
+    return {
+      id,
+      debag,
+      movies,
+      movie,
+    }
+  },
+})
+</script>

--- a/frontend/pages/movies/_id/show.vue
+++ b/frontend/pages/movies/_id/show.vue
@@ -38,23 +38,27 @@
                 {{ new Date(movie.created_at).toLocaleString() }}
               </td>
             </tr>
+            <tr>
+              <th class="body-1 font-weight-bold">動画紹介</th>
+              <td class="body-1">
+                {{ movie.introduction }}
+              </td>
+            </tr>
           </tbody>
         </template>
       </v-simple-table>
     </v-card>
-    <button @click="debag">debug</button>
-    {{ movies }}
   </v-container>
 </template>
 
 <script lang="ts">
 import {
   defineComponent,
-  inject,
   useRoute,
+  inject,
   computed,
-  useFetch,
   ref,
+  useFetch,
 } from '@nuxtjs/composition-api'
 import movieKey from '@/store/movie/movieKey'
 import { Movie, UseMovie } from '@/store/movie/movieTypes'
@@ -65,17 +69,22 @@ export default defineComponent({
     const route = useRoute()
     const id = computed(() => route.value.params.id)
 
-    const { movies } = inject(movieKey) as UseMovie
+    const { movies, fetchMovies } = inject(movieKey) as UseMovie
 
-    const movie = ref<Movie>(
-      movies.value.find((movie: Movie) => {
+    const movie = ref({})
+
+    // const movie = ref(
+    //   movies.value.find((movie: Movie) => {
+    //     return movie.id === Number(id.value)
+    //   }),
+    // )
+
+    useFetch(async () => {
+      await fetchMovies()
+      movie.value = movies.value.find((movie: Movie) => {
         return movie.id === Number(id.value)
-      }),
-    )
-
-    const debag = () => {
-      console.log(movie)
-    }
+      })
+    })
 
     // const dialog = ref<boolean>(false)
 
@@ -87,14 +96,7 @@ export default defineComponent({
     //   dialog.value = false
     // }
 
-    // useFetch(async () => {
-    //   await fetchUser()
-    // })
-
     return {
-      id,
-      debag,
-      movies,
       movie,
     }
   },

--- a/frontend/pages/users/_id/show.vue
+++ b/frontend/pages/users/_id/show.vue
@@ -41,13 +41,7 @@
 </template>
 
 <script lang="ts">
-import {
-  defineComponent,
-  inject,
-  useFetch,
-  reactive,
-  ref,
-} from '@nuxtjs/composition-api'
+import { defineComponent, inject, useFetch, ref } from '@nuxtjs/composition-api'
 import userKey from '@/store/user/userKey'
 import { UseUser } from '@/store/user/userTypes'
 

--- a/frontend/store/movie/movieTypes.ts
+++ b/frontend/store/movie/movieTypes.ts
@@ -10,14 +10,6 @@ export interface Movie {
 }
 
 export interface UseMovie {
-  movie: DeepReadonly<Movie>
-  setMovie: (
-    id: number,
-    title: string,
-    introduction: string,
-    created_at: string,
-    movie_url: string,
-  ) => void
   movies: DeepReadonly<any>
   setMovies: (movie: Movie) => void
   fetchMovies: () => void

--- a/frontend/store/movie/movieTypes.ts
+++ b/frontend/store/movie/movieTypes.ts
@@ -1,7 +1,7 @@
 import { DeepReadonly } from '@nuxtjs/composition-api'
 
 export interface Movie {
-  id: 0
+  id: number
   title: string
   introduction: string
   created_at: string
@@ -10,6 +10,14 @@ export interface Movie {
 }
 
 export interface UseMovie {
+  movie: DeepReadonly<Movie>
+  setMovie: (
+    id: number,
+    title: string,
+    introduction: string,
+    created_at: string,
+    movie_url: string,
+  ) => void
   movies: DeepReadonly<any>
   setMovies: (movie: Movie) => void
   fetchMovies: () => void

--- a/frontend/store/movie/useMovie.ts
+++ b/frontend/store/movie/useMovie.ts
@@ -1,8 +1,37 @@
-import { ref, readonly } from '@nuxtjs/composition-api'
+import { ref, reactive, readonly } from '@nuxtjs/composition-api'
 import { Movie, UseMovie } from '@/store/movie/movieTypes'
 import axios from 'axios'
 
+const movie = reactive<Movie>({
+  id: 0,
+  title: '',
+  introduction: '',
+  created_at: '',
+  updated_at: '',
+  movie_url: '',
+})
+
+const setMovie = (
+  id: number,
+  title: string,
+  introduction: string,
+  created_at: string,
+  movie_url: string,
+) => {
+  movie.id = id
+  movie.title = title
+  movie.introduction = introduction
+  movie.created_at = created_at
+  movie.movie_url = movie_url
+}
+
 const movies = ref<Movie[]>([])
+
+const changeMovie = (id: Number) => {
+  const movie = movies.value.find((movie: Movie) => {
+    return movie.id === id
+  })
+}
 
 const setMovies = (movie: Movie) => {
   movies.value.push(movie)
@@ -26,6 +55,8 @@ const fetchMovies = async () => {
 }
 
 const useMovie: UseMovie = {
+  movie: readonly(movie),
+  setMovie,
   movies: readonly(movies),
   setMovies,
   fetchMovies,

--- a/frontend/store/movie/useMovie.ts
+++ b/frontend/store/movie/useMovie.ts
@@ -1,37 +1,8 @@
-import { ref, reactive, readonly } from '@nuxtjs/composition-api'
+import { ref, readonly } from '@nuxtjs/composition-api'
 import { Movie, UseMovie } from '@/store/movie/movieTypes'
 import axios from 'axios'
 
-const movie = reactive<Movie>({
-  id: 0,
-  title: '',
-  introduction: '',
-  created_at: '',
-  updated_at: '',
-  movie_url: '',
-})
-
-const setMovie = (
-  id: number,
-  title: string,
-  introduction: string,
-  created_at: string,
-  movie_url: string,
-) => {
-  movie.id = id
-  movie.title = title
-  movie.introduction = introduction
-  movie.created_at = created_at
-  movie.movie_url = movie_url
-}
-
 const movies = ref<Movie[]>([])
-
-const changeMovie = (id: Number) => {
-  const movie = movies.value.find((movie: Movie) => {
-    return movie.id === id
-  })
-}
 
 const setMovies = (movie: Movie) => {
   movies.value.push(movie)
@@ -55,8 +26,6 @@ const fetchMovies = async () => {
 }
 
 const useMovie: UseMovie = {
-  movie: readonly(movie),
-  setMovie,
   movies: readonly(movies),
   setMovies,
   fetchMovies,


### PR DESCRIPTION
・まず、動画一覧ページの表示をサムネイル表示に変更。その上で、サムネをクリックすると動画詳細ページに遷移するようにしています。

・詳細ページのレイアウトについても大まかに整えています。ただし、投稿者については投稿者と動画の紐付けが終わっていないので、（仮）と表示されるようにしています。加えて、編集、削除ボタンもレイアウトは作りましたが、機能については後ほど実装致します。

・また、リロードをしてもバックエンド側からデータを取得し、問題なく表示されるようにしています。

・ログインしているか？に関わらず、表示されるようにしています（未ログインでも許可）。ただし、編集と削除ボタンは投稿者のみ表示されるように、後ほど実装致します。