### PR TITLE
動画削除機能の実装 #31

### DIFF
--- a/backend/app/controllers/api/v1/movies_controller.rb
+++ b/backend/app/controllers/api/v1/movies_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::MoviesController < ApplicationController
-  skip_before_action :login_required, only: [:index, :show]
-  before_action :set_movie, only: :show
+  skip_before_action :login_required, only: [:index, :show, :destroy]
+  before_action :set_movie, only: [:show, :destroy]
 
   def index
     render json: Movie.all, methods: [:movie_url]
@@ -17,6 +17,11 @@ class Api::V1::MoviesController < ApplicationController
 
   def show
     render json: @movie, methods: [:movie_url]
+  end
+
+  def destroy
+    @movie.destroy
+    render json: @movie
   end
 
   private

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
       get "/user", to: "auth#get_current_user"
       delete "logout", to: "auth#logout"
 			resources :users, only: [:create, :update, :destroy]
-      resources :movies, only: [:index, :create, :show]
+      resources :movies, only: [:index, :create, :show, :destroy]
     end
   end
 end

--- a/frontend/components/movie/DeleteModal.vue
+++ b/frontend/components/movie/DeleteModal.vue
@@ -1,0 +1,69 @@
+<template>
+  <v-dialog v-model="dialog" width="500">
+    <v-card>
+      <v-card-title class="text-h5 grey lighten-2">
+        本当に削除しますか？
+      </v-card-title>
+      <v-divider></v-divider>
+      <v-card-actions>
+        <v-spacer></v-spacer>
+        <v-btn color="#f06966" text @click="deleteMovie">
+          削除する
+        </v-btn>
+        <v-btn color="#6abe83" text @click="callToDialogFalse">
+          戻る
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script lang="ts">
+import {
+  defineComponent,
+  useContext,
+  useRouter,
+  inject,
+} from '@nuxtjs/composition-api'
+import flashKey from '@/store/flash/flashKey'
+import { UseFlashMessage } from '@/store/flash/flashTypes'
+
+export default defineComponent({
+  props: {
+    dialog: {
+      type: Boolean,
+      required: true,
+    },
+    id: {
+      type: Number,
+      required: true,
+    },
+  },
+
+  setup(props, context) {
+    const { $axios } = useContext()
+    const router = useRouter()
+
+    const { displayFlashMessage } = inject(flashKey) as UseFlashMessage
+
+    const deleteMovie = async () => {
+      try {
+        await $axios.$delete(`/api/v1/movies/${props.id}`)
+        router.push('/')
+        displayFlashMessage('削除')
+      } catch (e) {
+        console.log(e)
+      }
+    }
+
+    const callToDialogFalse = () => {
+      context.emit('to-dialog-false')
+    }
+
+    return {
+      deleteMovie,
+      callToDialogFalse,
+    }
+  },
+})
+</script>

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -8,7 +8,6 @@
       />
       ログインユーザー
       {{ user }}
-      <br />
     </v-row>
   </div>
 </template>

--- a/frontend/pages/movies/_id/show.vue
+++ b/frontend/pages/movies/_id/show.vue
@@ -1,6 +1,10 @@
 <template>
   <v-container>
-    <!-- <UserDeleteModal :dialog="dialog" @to-dialog-false="toDialogFalse" /> -->
+    <MovieDeleteModal
+      :dialog="dialog"
+      :id="propsId"
+      @to-dialog-false="toDialogFalse"
+    />
     <v-card width="800px" class="mx-auto mt-5" elevation="1">
       <video
         :src="movie.movie_url"
@@ -17,10 +21,7 @@
           <v-btn color="#6abe83" class="white--text mr-3" :to="`/`" nuxt>
             編集
           </v-btn>
-          <!-- <v-btn color="#f06966" class="white--text" @click="toDialogTrue">
-            削除
-          </v-btn> -->
-          <v-btn color="#f06966" class="white--text">
+          <v-btn color="#f06966" class="white--text" @click="toDialogTrue">
             削除
           </v-btn>
         </v-card-actions>
@@ -68,6 +69,7 @@ export default defineComponent({
   setup() {
     const route = useRoute()
     const id = computed(() => route.value.params.id)
+    const propsId = ref<Number>(Number(id.value))
 
     const { movies, fetchMovies } = inject(movieKey) as UseMovie
 
@@ -86,18 +88,22 @@ export default defineComponent({
       })
     })
 
-    // const dialog = ref<boolean>(false)
+    const dialog = ref<boolean>(false)
 
-    // const toDialogTrue = () => {
-    //   dialog.value = true
-    // }
+    const toDialogTrue = () => {
+      dialog.value = true
+    }
 
-    // const toDialogFalse = () => {
-    //   dialog.value = false
-    // }
+    const toDialogFalse = () => {
+      dialog.value = false
+    }
 
     return {
       movie,
+      propsId,
+      dialog,
+      toDialogTrue,
+      toDialogFalse,
     }
   },
 })

--- a/frontend/pages/movies/_id/show.vue
+++ b/frontend/pages/movies/_id/show.vue
@@ -40,7 +40,7 @@
               </td>
             </tr>
             <tr>
-              <th class="body-1 font-weight-bold">動画紹介</th>
+              <th class="body-1 font-weight-bold" width="15%">動画紹介</th>
               <td class="body-1">
                 {{ movie.introduction }}
               </td>


### PR DESCRIPTION
・動画削除機能の実装をしました。ユーザー削除と同様に、削除確認のモーダルウィンドを表示するようにしています。なお、削除確認のモーダルウィンドウは DeleteModal.vueとして、コンポーネント化しています。

・動作確認中に、動画詳細ページで長い紹介文だとレイアウトが崩れることを発見しました。修正に手間がかからないことから、ついでに修正しています。