### PR TITLE
投稿動画とログインユーザーの紐付け#33

### DIFF
--- a/backend/app/controllers/api/v1/movies_controller.rb
+++ b/backend/app/controllers/api/v1/movies_controller.rb
@@ -20,6 +20,9 @@ class Api::V1::MoviesController < ApplicationController
   end
 
   def destroy
+    if @movie.user != current_user
+      return
+    end
     @movie.destroy
     render json: @movie
   end

--- a/backend/app/controllers/api/v1/movies_controller.rb
+++ b/backend/app/controllers/api/v1/movies_controller.rb
@@ -7,7 +7,7 @@ class Api::V1::MoviesController < ApplicationController
   end
 
   def create
-    movie = Movie.new(movie_params)
+    movie = current_user.movies.new(movie_params)
     if movie.save
       render json: movie, methods: [:movie_url]
     else

--- a/backend/app/controllers/api/v1/movies_controller.rb
+++ b/backend/app/controllers/api/v1/movies_controller.rb
@@ -3,7 +3,7 @@ class Api::V1::MoviesController < ApplicationController
   before_action :set_movie, only: [:show, :destroy]
 
   def index
-    render json: Movie.all, methods: [:movie_url]
+    render json: Movie.all.includes(:user), methods: [:movie_url]
   end
 
   def create

--- a/backend/app/controllers/api/v1/users_controller.rb
+++ b/backend/app/controllers/api/v1/users_controller.rb
@@ -1,7 +1,7 @@
 class Api::V1::UsersController < ApplicationController
   wrap_parameters include: [:name, :email, :password, :password_confirmation]
-  skip_before_action :login_required, only: :create
-  before_action :set_user, only: [:update, :destroy]
+  skip_before_action :login_required, only: [:create, :show]
+  before_action :set_user, only: [:update, :show, :destroy]
 
   def create
     user = User.new(user_params)
@@ -11,6 +11,10 @@ class Api::V1::UsersController < ApplicationController
       # 422でないとerrors.full_messagesが使えない
       render json: user.errors.full_messages, status: 422
     end
+  end
+
+  def show
+    render json: @user
   end
 
   def update

--- a/backend/app/models/movie.rb
+++ b/backend/app/models/movie.rb
@@ -8,6 +8,8 @@ class Movie < ApplicationRecord
   validates :movie, attached: true, content_type: { in: %w[video/mp4 video/mov video/wmv] }, 
             size: { less_than: 500.megabytes , message: 'ファイルサイズは500Mb以下にしてください' }
 
+  belongs_to :user
+
   def movie_url
     movie.attached? ? url_for(movie) : nil
   end 

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -7,4 +7,6 @@ class User < ApplicationRecord
   validates :name, presence: true, length: { maximum: 30 }
   validates :email, presence: true, uniqueness: true, format: { with: VALID_EMAIL_REGEX }, length: { maximum: 72 }
   validates :password, format: { with: VALID_PASSWORD_REGEX }, length: {minimum: 8, maximum: 30 }, on: :create
+
+  has_many :movies
 end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
       post "/login", to: "auth#login"
       get "/user", to: "auth#get_current_user"
       delete "logout", to: "auth#logout"
-			resources :users, only: [:create, :update, :destroy]
+			resources :users, only: [:create, :show, :update, :destroy]
       resources :movies, only: [:index, :create, :show, :destroy]
     end
   end

--- a/backend/db/migrate/20210828010847_add_user_id_to_movies.rb
+++ b/backend/db/migrate/20210828010847_add_user_id_to_movies.rb
@@ -1,0 +1,10 @@
+class AddUserIdToMovies < ActiveRecord::Migration[6.0]
+  def up
+    execute 'DELETE FROM movies;'
+    add_reference :movies, :user, null: false, index: true
+  end
+
+  def down
+    remove_reference :movies, :user, index: true
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_21_045554) do
+ActiveRecord::Schema.define(version: 2021_08_28_010847) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -38,6 +38,8 @@ ActiveRecord::Schema.define(version: 2021_08_21_045554) do
     t.text "introduction", limit: 200, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "user_id", null: false
+    t.index ["user_id"], name: "index_movies_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|

--- a/frontend/components/movie/Indivisual.vue
+++ b/frontend/components/movie/Indivisual.vue
@@ -40,10 +40,9 @@ export default defineComponent({
   },
   setup(props) {
     const { $axios } = useContext()
-
     const { movies } = inject(movieKey) as UseMovie
-    const movie = ref<Movie>(movies.value[props.index])
 
+    const movie = ref<Movie>(movies.value[props.index])
     const userName = ref<string>('')
 
     useFetch(async () => {

--- a/frontend/components/movie/Indivisual.vue
+++ b/frontend/components/movie/Indivisual.vue
@@ -10,10 +10,11 @@
           </p>
         </v-card-title>
         <v-card-subtitle>
-          投稿者：Guest
+          投稿者：
           <br />
           投稿日時：{{ new Date(movie.created_at).toLocaleString() }}
         </v-card-subtitle>
+        <button @click="debug">debug</button>
       </v-card>
     </nuxt-link>
   </v-col>
@@ -35,8 +36,13 @@ export default defineComponent({
     const { movies } = inject(movieKey) as UseMovie
     const movie = ref<Movie>(movies.value[props.index])
 
+    const debug = () => {
+      console.log(movie)
+    }
+
     return {
       movie,
+      debug,
     }
   },
 })

--- a/frontend/components/movie/Indivisual.vue
+++ b/frontend/components/movie/Indivisual.vue
@@ -10,20 +10,26 @@
           </p>
         </v-card-title>
         <v-card-subtitle>
-          投稿者：
+          投稿者：{{ userName }}
           <br />
           投稿日時：{{ new Date(movie.created_at).toLocaleString() }}
         </v-card-subtitle>
-        <button @click="debug">debug</button>
       </v-card>
     </nuxt-link>
   </v-col>
 </template>
 
 <script lang="ts">
-import { defineComponent, inject, ref } from '@nuxtjs/composition-api'
+import {
+  defineComponent,
+  useContext,
+  inject,
+  ref,
+  useFetch,
+} from '@nuxtjs/composition-api'
 import movieKey from '@/store/movie/movieKey'
 import { Movie, UseMovie } from '@/store/movie/movieTypes'
+import { User } from '@/store/user/userTypes'
 
 export default defineComponent({
   props: {
@@ -33,16 +39,28 @@ export default defineComponent({
     },
   },
   setup(props) {
+    const { $axios } = useContext()
+
     const { movies } = inject(movieKey) as UseMovie
     const movie = ref<Movie>(movies.value[props.index])
 
-    const debug = () => {
-      console.log(movie)
-    }
+    const userName = ref<string>('')
+
+    useFetch(async () => {
+      try {
+        const response: User = await $axios.$get(
+          `/api/v1/users/${movie.value.user_id}`,
+        )
+        userName.value = response.name
+      } catch (e) {
+        console.log(e)
+      }
+    })
 
     return {
       movie,
-      debug,
+      movies,
+      userName,
     }
   },
 })

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -8,12 +8,19 @@
       />
       ログインユーザー
       {{ user }}
+      <br />
+      {{ movies }}
     </v-row>
   </div>
 </template>
 
 <script lang="ts">
-import { defineComponent, useFetch, inject } from '@nuxtjs/composition-api'
+import {
+  defineComponent,
+  useContext,
+  inject,
+  useFetch,
+} from '@nuxtjs/composition-api'
 import userKey from '@/store/user/userKey'
 import { UseUser } from '@/store/user/userTypes'
 import movieKey from '@/store/movie/movieKey'
@@ -22,6 +29,8 @@ import { UseMovie } from '@/store/movie/movieTypes'
 export default defineComponent({
   auth: false,
   setup() {
+    const { $axios } = useContext()
+
     const { user, fetchUser } = inject(userKey) as UseUser
     const { movies, fetchMovies } = inject(movieKey) as UseMovie
 

--- a/frontend/pages/movies/_id/show.vue
+++ b/frontend/pages/movies/_id/show.vue
@@ -31,7 +31,7 @@
           <tbody>
             <tr>
               <th class="body-1 font-weight-bold">投稿者</th>
-              <td class="body-1">（仮）</td>
+              <td class="body-1">{{ userName }}</td>
             </tr>
             <tr>
               <th class="body-1 font-weight-bold">投稿日</th>
@@ -55,25 +55,40 @@
 <script lang="ts">
 import {
   defineComponent,
+  useContext,
   useRoute,
   inject,
   computed,
   ref,
+  reactive,
   useFetch,
 } from '@nuxtjs/composition-api'
 import movieKey from '@/store/movie/movieKey'
 import { Movie, UseMovie } from '@/store/movie/movieTypes'
+import { User } from '@/store/user/userTypes'
 
 export default defineComponent({
   auth: false,
   setup() {
+    const { $axios } = useContext()
     const route = useRoute()
+
     const id = computed(() => route.value.params.id)
     const propsId = ref<Number>(Number(id.value))
 
     const { movies, fetchMovies } = inject(movieKey) as UseMovie
 
-    const movie = ref({})
+    const movie = reactive<Movie>({
+      id: 0,
+      title: '',
+      introduction: '',
+      created_at: '',
+      updated_at: '',
+      movie_url: '',
+      user_id: 0,
+    })
+
+    const userName = ref<string>('')
 
     // const movie = ref(
     //   movies.value.find((movie: Movie) => {
@@ -83,9 +98,23 @@ export default defineComponent({
 
     useFetch(async () => {
       await fetchMovies()
-      movie.value = movies.value.find((movie: Movie) => {
+      const gotMovie = movies.value.find((movie: Movie) => {
         return movie.id === Number(id.value)
       })
+      movie.id = gotMovie.id
+      movie.title = gotMovie.title
+      movie.introduction = gotMovie.introduction
+      movie.created_at = gotMovie.created_at
+      movie.movie_url = gotMovie.movie_url
+      movie.user_id = gotMovie.user_id
+      try {
+        const response: User = await $axios.$get(
+          `/api/v1/users/${movie.user_id}`,
+        )
+        userName.value = response.name
+      } catch (e) {
+        console.log(e)
+      }
     })
 
     const dialog = ref<boolean>(false)
@@ -100,6 +129,7 @@ export default defineComponent({
 
     return {
       movie,
+      userName,
       propsId,
       dialog,
       toDialogTrue,

--- a/frontend/pages/movies/_id/show.vue
+++ b/frontend/pages/movies/_id/show.vue
@@ -17,7 +17,8 @@
           {{ movie.title }}
         </h1>
         <v-spacer></v-spacer>
-        <v-card-actions>
+        {{ isPostUser }}
+        <v-card-actions v-if="isPostUser">
           <v-btn color="#6abe83" class="white--text mr-3" :to="`/`" nuxt>
             編集
           </v-btn>
@@ -62,10 +63,12 @@ import {
   ref,
   reactive,
   useFetch,
+  ComputedRef,
 } from '@nuxtjs/composition-api'
 import movieKey from '@/store/movie/movieKey'
 import { Movie, UseMovie } from '@/store/movie/movieTypes'
-import { User } from '@/store/user/userTypes'
+import { User, UseUser } from '@/store/user/userTypes'
+import userKey from '@/store/user/userKey'
 
 export default defineComponent({
   auth: false,
@@ -77,6 +80,7 @@ export default defineComponent({
     const propsId = ref<Number>(Number(id.value))
 
     const { movies, fetchMovies } = inject(movieKey) as UseMovie
+    const { user } = inject(userKey) as UseUser
 
     const movie = reactive<Movie>({
       id: 0,
@@ -90,11 +94,9 @@ export default defineComponent({
 
     const userName = ref<string>('')
 
-    // const movie = ref(
-    //   movies.value.find((movie: Movie) => {
-    //     return movie.id === Number(id.value)
-    //   }),
-    // )
+    const isPostUser: ComputedRef<boolean> = computed(() => {
+      return movie.user_id === user.id ? true : false
+    })
 
     useFetch(async () => {
       await fetchMovies()
@@ -130,6 +132,7 @@ export default defineComponent({
     return {
       movie,
       userName,
+      isPostUser,
       propsId,
       dialog,
       toDialogTrue,

--- a/frontend/pages/movies/_id/show.vue
+++ b/frontend/pages/movies/_id/show.vue
@@ -17,7 +17,6 @@
           {{ movie.title }}
         </h1>
         <v-spacer></v-spacer>
-        {{ isPostUser }}
         <v-card-actions v-if="isPostUser">
           <v-btn color="#6abe83" class="white--text mr-3" :to="`/`" nuxt>
             編集

--- a/frontend/store/movie/movieTypes.ts
+++ b/frontend/store/movie/movieTypes.ts
@@ -7,6 +7,7 @@ export interface Movie {
   created_at: string
   updated_at: string
   movie_url: string
+  user_id: number
 }
 
 export interface UseMovie {


### PR DESCRIPTION
・投稿動画とログインユーザーの紐付けを行いました。そのため、ログインユーザーが投稿すると、そのユーザーが投稿者となるように設定しています。

・また、一覧表示時にN+1問題が発生しないように実装しました。

・フロントエンド 側で投稿者名を仮名にしていましたが、きちんと表示されるように実装しています。また、ページを更新しても問題なく表示されるように留意しました。

・加えて、動画詳細ページで、投稿者が閲覧した時のみ、編集ボタンと削除ボタンが表示されるように実装しました。