### PR TITLE
動画編集機能の実装#35

### DIFF
--- a/backend/app/controllers/api/v1/movies_controller.rb
+++ b/backend/app/controllers/api/v1/movies_controller.rb
@@ -1,6 +1,7 @@
 class Api::V1::MoviesController < ApplicationController
-  skip_before_action :login_required, only: [:index, :show, :destroy]
-  before_action :set_movie, only: [:show, :destroy]
+  skip_before_action :login_required, only: [:index, :show]
+  before_action :set_movie, only: [:show, :update, :destroy]
+  before_action :is_post_user?, only: [:update, :destroy]
 
   def index
     render json: Movie.all.includes(:user), methods: [:movie_url]
@@ -19,10 +20,15 @@ class Api::V1::MoviesController < ApplicationController
     render json: @movie, methods: [:movie_url]
   end
 
-  def destroy
-    if @movie.user != current_user
-      return
+  def update
+    if @movie.update(movie_edit_params)
+      render json: @movie
+    else
+      render json: @movie.errors.full_messages, status: 422
     end
+  end
+
+  def destroy
     @movie.destroy
     render json: @movie
   end
@@ -33,7 +39,17 @@ class Api::V1::MoviesController < ApplicationController
     params.require(:movie).permit(:title, :introduction, :movie)
   end
 
+  def movie_edit_params
+    params.require(:movie).permit(:title, :introduction)
+  end
+
   def set_movie
     @movie = Movie.find(params[:id])
+  end
+
+  def is_post_user?
+    if @movie.user != current_user
+      return
+    end
   end
 end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
       get "/user", to: "auth#get_current_user"
       delete "logout", to: "auth#logout"
 			resources :users, only: [:create, :show, :update, :destroy]
-      resources :movies, only: [:index, :create, :show, :destroy]
+      resources :movies, only: [:index, :create, :show, :update, :destroy]
     end
   end
 end

--- a/frontend/components/movie/FormIntroduction.vue
+++ b/frontend/components/movie/FormIntroduction.vue
@@ -3,6 +3,7 @@
     filled
     :rules="rules"
     :counter="max"
+    :value="props.introduction"
     @input="handleInput"
     label="投稿コメント"
   ></v-textarea>
@@ -12,7 +13,13 @@
 import { defineComponent } from '@nuxtjs/composition-api'
 
 export default defineComponent({
-  setup(_, context) {
+  props: {
+    introduction: {
+      type: String,
+      reqruied: true,
+    },
+  },
+  setup(props, context) {
     const handleInput = (event: Event) => {
       context.emit('input', event)
     }
@@ -20,6 +27,7 @@ export default defineComponent({
     const max = 200
 
     return {
+      props,
       handleInput,
       max,
       rules: [

--- a/frontend/components/movie/FormTitle.vue
+++ b/frontend/components/movie/FormTitle.vue
@@ -3,6 +3,7 @@
     type="text"
     :rules="rules"
     :counter="max"
+    :value="props.title"
     @input="handleInput"
     prepend-icon="mdi-clipboard-play-outline"
     label="タイトル"
@@ -10,10 +11,17 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from '@nuxtjs/composition-api'
+import { defineComponent, ref } from '@nuxtjs/composition-api'
 
 export default defineComponent({
-  setup(_, context) {
+  props: {
+    title: {
+      type: String,
+      required: true,
+    },
+  },
+
+  setup(props, context) {
     const handleInput = (event: Event) => {
       context.emit('input', event)
     }
@@ -22,6 +30,7 @@ export default defineComponent({
 
     return {
       handleInput,
+      props,
       max,
       rules: [
         // ||の左側はバリデーションの成功。!!vはvalueが存在していること。

--- a/frontend/pages/movies/_id/edit.vue
+++ b/frontend/pages/movies/_id/edit.vue
@@ -1,0 +1,140 @@
+<template>
+  <v-container>
+    <v-card width="500px" class="mx-auto mt-5" elevation="1">
+      <v-card-title>
+        <h1 class="headline">動画編集{{ inputMovie }}</h1>
+      </v-card-title>
+      <ErrorMessage :errors="errorMessages" />
+      <v-card-text>
+        <v-form ref="form" lazy-validation>
+          <MovieFormTitle
+            v-model="inputMovie.title"
+            :title="inputMovie.title"
+          />
+          <MovieFormIntroduction
+            v-model="inputMovie.introduction"
+            :introduction="inputMovie.introduction"
+          />
+          <v-card-actions>
+            <v-btn color="#6abe83" class="white--text" @click="test">
+              編集
+            </v-btn>
+            <v-btn
+              color="#f1ac9d"
+              class="white--text"
+              :to="`/movies/${movieId}/show`"
+              nuxt
+            >
+              戻る
+            </v-btn>
+          </v-card-actions>
+        </v-form>
+      </v-card-text>
+    </v-card>
+  </v-container>
+</template>
+
+<script lang="ts">
+import {
+  defineComponent,
+  useContext,
+  useRouter,
+  inject,
+  useFetch,
+  reactive,
+  ref,
+  useRoute,
+  computed,
+  ComputedRef,
+} from '@nuxtjs/composition-api'
+import userKey from '@/store/user/userKey'
+import { User, UseUser } from '@/store/user/userTypes'
+import flashKey from '@/store/flash/flashKey'
+import { UseFlashMessage } from '@/store/flash/flashTypes'
+import movieKey from '@/store/movie/movieKey'
+import { Movie, UseMovie } from '@/store/movie/movieTypes'
+
+export default defineComponent({
+  setup() {
+    const { $axios } = useContext()
+    const router = useRouter()
+    const route = useRoute()
+
+    const id: ComputedRef<number> = computed(() =>
+      Number(route.value.params.id),
+    )
+
+    const { displayFlashMessage } = inject(flashKey) as UseFlashMessage
+    const { movies, fetchMovies } = inject(movieKey) as UseMovie
+
+    // const movie = reactive<Movie>({
+    //   id: 0,
+    //   title: '',
+    //   introduction: '',
+    //   created_at: '',
+    //   updated_at: '',
+    //   movie_url: '',
+    //   user_id: 0,
+    // })
+
+    const movieId = ref<number>(0)
+
+    interface InputMovie {
+      title: string
+      introduction: string
+    }
+
+    const inputMovie = reactive<InputMovie>({
+      title: '',
+      introduction: '',
+    })
+
+    useFetch(async () => {
+      await fetchMovies()
+      const gotMovie = movies.value.find((movie: Movie) => {
+        return movie.id === Number(id.value)
+      })
+      // movie.id = gotMovie.id
+      // movie.title = gotMovie.title
+      // movie.introduction = gotMovie.introduction
+      // movie.created_at = gotMovie.created_at
+      // movie.movie_url = gotMovie.movie_url
+      // movie.user_id = gotMovie.user_id
+      movieId.value = gotMovie.id
+      inputMovie.title = gotMovie.title
+      inputMovie.introduction = gotMovie.introduction
+    })
+
+    const errorMessages = ref<string[]>([])
+
+    // const editUser = async () => {
+    //   try {
+    //     const response: User = await $axios.$put(
+    //       `/api/v1/users/${user.id}`,
+    //       inputUser,
+    //       {
+    //         withCredentials: true,
+    //       },
+    //     )
+    //     setUser(response.id, response.name, response.email)
+    //     router.push(`/users/${response.id}/show`)
+    //     displayFlashMessage('編集')
+    //   } catch (e) {
+    //     errorMessages.value = e.response.data
+    //   }
+    // }
+
+    const test = () => {
+      console.log('kazuya')
+    }
+
+    return {
+      // movie,
+      movieId,
+      inputMovie,
+      errorMessages,
+      test,
+    }
+  },
+})
+</script>

--- a/frontend/pages/movies/_id/edit.vue
+++ b/frontend/pages/movies/_id/edit.vue
@@ -16,7 +16,7 @@
             :introduction="inputMovie.introduction"
           />
           <v-card-actions>
-            <v-btn color="#6abe83" class="white--text" @click="test">
+            <v-btn color="#6abe83" class="white--text" @click="editMovie">
               編集
             </v-btn>
             <v-btn
@@ -107,33 +107,24 @@ export default defineComponent({
 
     const errorMessages = ref<string[]>([])
 
-    // const editUser = async () => {
-    //   try {
-    //     const response: User = await $axios.$put(
-    //       `/api/v1/users/${user.id}`,
-    //       inputUser,
-    //       {
-    //         withCredentials: true,
-    //       },
-    //     )
-    //     setUser(response.id, response.name, response.email)
-    //     router.push(`/users/${response.id}/show`)
-    //     displayFlashMessage('編集')
-    //   } catch (e) {
-    //     errorMessages.value = e.response.data
-    //   }
-    // }
-
-    const test = () => {
-      console.log('kazuya')
+    const editMovie = async () => {
+      try {
+        const response: Movie = await $axios.$put(
+          `/api/v1/movies/${movieId.value}`,
+          inputMovie,
+        )
+        router.push(`/movies/${movieId.value}/show`)
+        displayFlashMessage('編集')
+      } catch (e) {
+        errorMessages.value = e.response.data
+      }
     }
 
     return {
-      // movie,
       movieId,
       inputMovie,
       errorMessages,
-      test,
+      editMovie,
     }
   },
 })

--- a/frontend/pages/movies/_id/edit.vue
+++ b/frontend/pages/movies/_id/edit.vue
@@ -2,7 +2,7 @@
   <v-container>
     <v-card width="500px" class="mx-auto mt-5" elevation="1">
       <v-card-title>
-        <h1 class="headline">動画編集{{ inputMovie }}</h1>
+        <h1 class="headline">動画編集</h1>
       </v-card-title>
       <ErrorMessage :errors="errorMessages" />
       <v-card-text>
@@ -67,16 +67,6 @@ export default defineComponent({
     const { displayFlashMessage } = inject(flashKey) as UseFlashMessage
     const { movies, fetchMovies } = inject(movieKey) as UseMovie
 
-    // const movie = reactive<Movie>({
-    //   id: 0,
-    //   title: '',
-    //   introduction: '',
-    //   created_at: '',
-    //   updated_at: '',
-    //   movie_url: '',
-    //   user_id: 0,
-    // })
-
     const movieId = ref<number>(0)
 
     interface InputMovie {
@@ -94,12 +84,6 @@ export default defineComponent({
       const gotMovie = movies.value.find((movie: Movie) => {
         return movie.id === Number(id.value)
       })
-      // movie.id = gotMovie.id
-      // movie.title = gotMovie.title
-      // movie.introduction = gotMovie.introduction
-      // movie.created_at = gotMovie.created_at
-      // movie.movie_url = gotMovie.movie_url
-      // movie.user_id = gotMovie.user_id
       movieId.value = gotMovie.id
       inputMovie.title = gotMovie.title
       inputMovie.introduction = gotMovie.introduction

--- a/frontend/pages/movies/_id/show.vue
+++ b/frontend/pages/movies/_id/show.vue
@@ -36,7 +36,7 @@
           <tbody>
             <tr>
               <th class="body-1 font-weight-bold">投稿者</th>
-              <td class="body-1">{{ userName }}</td>
+              <td class="body-1">{{ postUserName }}</td>
             </tr>
             <tr>
               <th class="body-1 font-weight-bold">投稿日</th>
@@ -85,7 +85,7 @@ export default defineComponent({
     )
 
     const { movies, fetchMovies } = inject(movieKey) as UseMovie
-    const { user } = inject(userKey) as UseUser
+    const { user, fetchUser } = inject(userKey) as UseUser
 
     const movie = reactive<Movie>({
       id: 0,
@@ -97,17 +97,14 @@ export default defineComponent({
       user_id: 0,
     })
 
-    const userName = ref<string>('')
-
-    const isPostUser: ComputedRef<boolean> = computed(() => {
-      return movie.user_id === user.id ? true : false
-    })
+    const postUserName = ref<string>('')
 
     useFetch(async () => {
       await fetchMovies()
       const gotMovie = movies.value.find((movie: Movie) => {
         return movie.id === Number(id.value)
       })
+      fetchUser()
       movie.id = gotMovie.id
       movie.title = gotMovie.title
       movie.introduction = gotMovie.introduction
@@ -118,10 +115,14 @@ export default defineComponent({
         const response: User = await $axios.$get(
           `/api/v1/users/${movie.user_id}`,
         )
-        userName.value = response.name
+        postUserName.value = response.name
       } catch (e) {
         console.log(e)
       }
+    })
+
+    const isPostUser: ComputedRef<boolean> = computed(() => {
+      return movie.user_id === user.id ? true : false
     })
 
     const dialog = ref<boolean>(false)
@@ -136,7 +137,7 @@ export default defineComponent({
 
     return {
       movie,
-      userName,
+      postUserName,
       isPostUser,
       id,
       dialog,

--- a/frontend/pages/movies/_id/show.vue
+++ b/frontend/pages/movies/_id/show.vue
@@ -2,7 +2,7 @@
   <v-container>
     <MovieDeleteModal
       :dialog="dialog"
-      :id="propsId"
+      :id="id"
       @to-dialog-false="toDialogFalse"
     />
     <v-card width="800px" class="mx-auto mt-5" elevation="1">
@@ -18,7 +18,12 @@
         </h1>
         <v-spacer></v-spacer>
         <v-card-actions v-if="isPostUser">
-          <v-btn color="#6abe83" class="white--text mr-3" :to="`/`" nuxt>
+          <v-btn
+            color="#6abe83"
+            class="white--text mr-3"
+            :to="`/movies/${id}/edit`"
+            nuxt
+          >
             編集
           </v-btn>
           <v-btn color="#f06966" class="white--text" @click="toDialogTrue">
@@ -75,8 +80,9 @@ export default defineComponent({
     const { $axios } = useContext()
     const route = useRoute()
 
-    const id = computed(() => route.value.params.id)
-    const propsId = ref<Number>(Number(id.value))
+    const id: ComputedRef<number> = computed(() =>
+      Number(route.value.params.id),
+    )
 
     const { movies, fetchMovies } = inject(movieKey) as UseMovie
     const { user } = inject(userKey) as UseUser
@@ -132,7 +138,7 @@ export default defineComponent({
       movie,
       userName,
       isPostUser,
-      propsId,
+      id,
       dialog,
       toDialogTrue,
       toDialogFalse,

--- a/frontend/pages/movies/new.vue
+++ b/frontend/pages/movies/new.vue
@@ -9,9 +9,15 @@
       <ErrorMessage :errors="errorMessages" />
       <v-card-text>
         <v-form ref="form" lazy-validation>
-          <MovieFormTitle v-model="inputMovie.title" />
+          <MovieFormTitle
+            v-model="inputMovie.title"
+            :title="inputMovie.title"
+          />
           <MovieFormVideo @set-image="setImage" />
-          <MovieFormIntroduction v-model="inputMovie.introduction" />
+          <MovieFormIntroduction
+            v-model="inputMovie.introduction"
+            :title="inputMovie.introduction"
+          />
           <v-card-actions>
             <v-btn color="#6abe83" class="white--text" @click="registerUser">
               新規投稿


### PR DESCRIPTION
・ movies/:id/editページを作成し、動画編集ページのレイアウトと編集機能の実装を致しました。また、編集後は動画詳細ページに戻るようにしています。

・バックエンド側では投稿者以外が編集できないように設定致しました。

・また、実装中に動画編集ページから動画詳細ページに戻った時に、編集・削除ボタンが消えるという不具合を見つけました。原因については表示の切り替えをログインユーザーと投稿ユーザーが同じかどうか？で判定していましたが、ログインユーザーの取得が原因でした。こちらについても、修正しています。

・尚、個別動画データの取得は動画編集と詳細ページで共通化できると考えました。しかし、コード量は少ない上、他で使う機会も今のところはなく、逆にコード量が多くなるため、そのまま各ページに実装コードを書きました。