### PR TITLE
feature:ユーザー削除と同時に投稿動画も削除されるように実装#39

### DIFF
--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -8,5 +8,5 @@ class User < ApplicationRecord
   validates :email, presence: true, uniqueness: true, format: { with: VALID_EMAIL_REGEX }, length: { maximum: 72 }
   validates :password, format: { with: VALID_PASSWORD_REGEX }, length: {minimum: 8, maximum: 30 }, on: :create
 
-  has_many :movies
+  has_many :movies, :dependent => :destroy
 end

--- a/frontend/components/movie/DeleteModal.vue
+++ b/frontend/components/movie/DeleteModal.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-dialog v-model="dialog" width="500">
+  <v-dialog v-model="dialog" persistent width="500">
     <v-card>
       <v-card-title class="text-h5 grey lighten-2">
         本当に削除しますか？

--- a/frontend/components/user/DeleteModal.vue
+++ b/frontend/components/user/DeleteModal.vue
@@ -1,10 +1,14 @@
 <template>
-  <v-dialog v-model="dialog" width="500">
+  <v-dialog v-model="dialog" persistent width="500">
     <v-card>
-      <v-card-title class="text-h5 grey lighten-2">
+      <v-card-title class="text-h5 grey lighten-2 mb-7">
         本当に削除しますか？
       </v-card-title>
-      <v-divider></v-divider>
+      <v-card-text>
+        <v-alert dense outlined type="error">
+          ユーザーを削除すると、投稿した動画も一緒に削除されますので、ご注意ください。
+        </v-alert>
+      </v-card-text>
       <v-card-actions>
         <v-spacer></v-spacer>
         <v-btn color="#f06966" text @click="deleteUser">

--- a/frontend/pages/login.vue
+++ b/frontend/pages/login.vue
@@ -9,6 +9,12 @@
       <ErrorMessage :errors="errorMessages" />
       <v-card-text>
         <v-form ref="form" lazy-validation>
+          <p>ゲストユーザー用</p>
+          <p>ログインID：test@test.com</p>
+          <p>パスワード：password</p>
+          <p>
+            ※ゲストユーザーでユーザー削除を行った場合、大変お手数ですが、同様のユーザー情報で新規ユーザー登録いただけると、ありがたいです（ユーザー名についてはtestとしていただけると幸いです）。
+          </p>
           <UserFormEmail v-model="inputUser.email" />
           <UserFormPassword v-model="inputUser.password" />
           <v-card-actions class="mt-3">


### PR DESCRIPTION
・ユーザ削除と同時に投稿動画も削除されるように実装しました。その際、削除確認のダイアログで、注意喚起のメッセージも追加致しました。

・実装中、削除確認のモーダルで、画面外を押すと、エラーが発生し、削除ボタンが押せなくなる不具合を発見しました。そのため、画面外での表示の切り替えをNGとし、戻るボタンでの遷移のみとしました。

・尚、今後の動作確認のために、ログインページでゲストユーザー情報を表示するようにしました。