### PR TITLE
Nuxtでのaxios設定見直し#43

### DIFF
--- a/frontend/nuxt.config.js
+++ b/frontend/nuxt.config.js
@@ -52,14 +52,15 @@ export default {
   // Axios module configuration: https://go.nuxtjs.dev/config-axios
   axios: {
     // baseURL: 'http://localhost:3000',
-    proxy: true,
+    baseURL: 'https://api-piano-video-share.herokuapp.com/',
+    // proxy: true,
     // withCredentials: true,
   },
 
-  proxy: {
-    // '/api/': 'http://localhost:3000',
-    '/api/': 'https://api-piano-video-share.herokuapp.com/',
-  },
+  // proxy: {
+  // '/api/': 'http://localhost:3000',
+  //   '/api/': 'https://api-piano-video-share.herokuapp.com/',
+  // },
 
   router: {
     middleware: ['auth'],


### PR DESCRIPTION
・前回の プルリクエストをマージした後に、デプロイしたアプリの動作検証をしたところ、バックエンド側との通信がうまくできていませんでした。

・エラーを確認したところ、リクエスト先がバックエンドではなく、フロントエンドがわのURLが使われていることから、axiosの設定に原因があると考えました。

・今まではproxyを使って、スマートに書いていましたが、動かなければ意味がないので、axiosのbaseUrlにバックエンドのurlを指定致しました。

・検証はmerge後にnetlifyが更新された後になります。検証し、問題なければ次の機能の実装に移ります。