### PR TITLE
Nuxtでのaxios、proxyの設定の再見直し#45

### DIFF
--- a/frontend/nuxt.config.js
+++ b/frontend/nuxt.config.js
@@ -52,15 +52,15 @@ export default {
   // Axios module configuration: https://go.nuxtjs.dev/config-axios
   axios: {
     // baseURL: 'http://localhost:3000',
-    baseURL: 'https://api-piano-video-share.herokuapp.com/',
-    // proxy: true,
+    // baseURL: 'https://api-piano-video-share.herokuapp.com/',
+    proxy: true,
     // withCredentials: true,
   },
 
-  // proxy: {
-  // '/api/': 'http://localhost:3000',
-  //   '/api/': 'https://api-piano-video-share.herokuapp.com/',
-  // },
+  proxy: {
+    // '/api/': 'http://localhost:3000',
+    '/api/': 'https://api-piano-video-share.herokuapp.com',
+  },
 
   router: {
     middleware: ['auth'],


### PR DESCRIPTION
 ・proxyを使わず、axiosのbaseURLに直接バックエンドのURLを書いたが、うまく動作しませんでした。よくコードを見ると、urlの末尾に/をつけていた。おそらく、この/が余計で、//ap1/v1のようになっていると思われます。

・そこで/を消すのはもちろん、proxyが原因でなかったと思われるので、proxyについても再度設定致します。

・その後、前回同様にプルリクエストをマージしていただいた後に、動作の検証を致します。