### PR TITLE
feature:Rails側のhost設定 Nuxtのaxios設定の見直し#47

### DIFF
--- a/backend/config/environments/production.rb
+++ b/backend/config/environments/production.rb
@@ -102,4 +102,6 @@ Rails.application.configure do
   # config.active_record.database_selector = { delay: 2.seconds }
   # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
+  host = 'https://api-piano-video-share.herokuapp.com/'
+  Rails.application.routes.default_url_options[:host] = host
 end

--- a/frontend/nuxt.config.js
+++ b/frontend/nuxt.config.js
@@ -52,15 +52,15 @@ export default {
   // Axios module configuration: https://go.nuxtjs.dev/config-axios
   axios: {
     // baseURL: 'http://localhost:3000',
-    // baseURL: 'https://api-piano-video-share.herokuapp.com/',
-    proxy: true,
+    baseURL: 'https://api-piano-video-share.herokuapp.com',
+    // proxy: true,
     // withCredentials: true,
   },
 
-  proxy: {
-    // '/api/': 'http://localhost:3000',
-    '/api/': 'https://api-piano-video-share.herokuapp.com',
-  },
+  // proxy: {
+  // '/api/': 'http://localhost:3000',
+  //   '/api/': 'https://api-piano-video-share.herokuapp.com',
+  // },
 
   router: {
     middleware: ['auth'],


### PR DESCRIPTION
・Nuxt側のaxios設定などの修正を試してが、上手く通信ができませんでした。。そのため、バックエンド側に問題がると推定。動画の取得一覧であれば、ログイン等も不要であるため、直接apiを叩き、実行結果を確認し増田。すると、500エラーが出たため、heroku のlogを確認したところ、ArgumentError (Missing host to link to! Please provide the :host parameter, set default_url_options[:host]となっていため、host設定をしました。

・その後、herokuに再度デプロイし、再度直接apiを叩いたところ、問題なく動画一覧を取得できました。

・ただし、デプロイしているフロントエンド側からリクエストを送っても、404エラーとなりました。herokuのlogを確認しても、履歴が残っていないため、そもそもリクエストが届いていないと判断しました。

・そのため、再度proxyではなく、axiosのbaseURLにバックエンド側のURLを記載しました。マージ後、再デプロイされた後に動作確認し、動かないようであれば、違う原因を探ります。